### PR TITLE
skip t0118_gateway_car_test.go for now

### DIFF
--- a/tests/t0118_gateway_car_test.go
+++ b/tests/t0118_gateway_car_test.go
@@ -74,6 +74,7 @@ func TestGatewayCar(t *testing.T) {
 				).Response(),
 		},
 	}
-
-	Run(t, tests)
+	
+	// Skip until https://github.com/ipfs/kubo/issues/9651 is resolved
+	// Run(t, tests)
 }

--- a/tests/t0118_gateway_car_test.go
+++ b/tests/t0118_gateway_car_test.go
@@ -1,6 +1,6 @@
-/* Skip until https://github.com/ipfs/kubo/issues/9651 is resolved
 package main
 
+/* Skip until https://github.com/ipfs/kubo/issues/9651 is resolved
 import (
 	"fmt"
 	"testing"
@@ -75,7 +75,7 @@ func TestGatewayCar(t *testing.T) {
 				).Response(),
 		},
 	}
-	
+
 	Run(t, tests)
 }
 */

--- a/tests/t0118_gateway_car_test.go
+++ b/tests/t0118_gateway_car_test.go
@@ -1,3 +1,4 @@
+/* Skip until https://github.com/ipfs/kubo/issues/9651 is resolved
 package main
 
 import (
@@ -75,6 +76,6 @@ func TestGatewayCar(t *testing.T) {
 		},
 	}
 	
-	// Skip until https://github.com/ipfs/kubo/issues/9651 is resolved
-	// Run(t, tests)
+	Run(t, tests)
 }
+*/


### PR DESCRIPTION
Let's skip the test until the implementation is fixed. We want the CI here to be able to tell us if the framework is doing alright. 