### PR TITLE
fix: move every test to sugar API

### DIFF
--- a/tests/t0113_gateway_symlink_test.go
+++ b/tests/t0113_gateway_symlink_test.go
@@ -1,35 +1,34 @@
 package tests
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/ipfs/gateway-conformance/tooling/car"
 	"github.com/ipfs/gateway-conformance/tooling/test"
+	. "github.com/ipfs/gateway-conformance/tooling/test"
 )
 
 func TestGatewaySymlink(t *testing.T) {
 	fixture := car.MustOpenUnixfsCar("t0113-gateway-symlink.car")
-	tests := []test.CTest{
+
+	tests := []CTest{
 		{
 			Name: "Test the directory listing",
-			Request: test.CRequest{
-				Path: fmt.Sprintf("ipfs/%s?format=raw", fixture.MustGetCid()),
-			},
-			Response: test.CResponse{
-				StatusCode: 200,
-				Body:       fixture.MustGetRawData(),
-			},
+			Request: Request().
+				Path("ipfs/%s?format=raw", fixture.MustGetCid()).Request(),
+			Response: Expect().
+				Status(200).
+				Body(fixture.MustGetRawData()).
+				Response(),
 		},
 		{
 			Name: "Test the symlink",
-			Request: test.CRequest{
-				Path: fmt.Sprintf("ipfs/%s/bar", fixture.MustGetCid()),
-			},
-			Response: test.CResponse{
-				StatusCode: 200,
-				Body:       []byte("foo"),
-			},
+			Request: Request().
+				Path("ipfs/%s/bar", fixture.MustGetCid()).Request(),
+			Response: Expect().
+				Status(200).
+				Bytes("foo").
+				Response(),
 		},
 	}
 

--- a/tests/t0114_gateway_subdomains_test.go
+++ b/tests/t0114_gateway_subdomains_test.go
@@ -67,8 +67,7 @@ func TestGatewaySubdomains(t *testing.T) {
 					Context: https://github.com/ipfs/go-ipfs/issues/6975					
 				`,
 					IsEqual("hello\n"),
-				).
-				Response(),
+				),
 		))
 
 		with(testGatewayWithManyProtocols(t,
@@ -84,7 +83,7 @@ func TestGatewaySubdomains(t *testing.T) {
 					Header("Location").
 						Hint("request for example.com/ipfs/{DirCID} returns Location HTTP header for subdomain redirect in browsers").
 						Contains("%s://%s.ipfs.%s/", u.Scheme, DirCID, u.Host),
-				).Response(),
+				),
 		))
 
 		with(testGatewayWithManyProtocols(t,
@@ -97,7 +96,7 @@ func TestGatewaySubdomains(t *testing.T) {
 					Header("Location").
 						Hint("request for example.com/ipfs/{CIDv0to1} returns Location HTTP header for subdomain redirect in browsers").
 						Contains("%s://%s.ipfs.%s/", u.Scheme, CIDv0to1, u.Host),
-				).Response(),
+				),
 		))
 
 		// TODO: ipns
@@ -114,8 +113,7 @@ func TestGatewaySubdomains(t *testing.T) {
 			URL("%s://%s.ipfs.%s", u.Scheme, CIDv1, u.Host),
 			Expect().
 				Status(200).
-				Body(Contains(CIDVal)).
-				Response(),
+				Body(Contains(CIDVal)),
 		))
 
 		with(testGatewayWithManyProtocols(t,
@@ -123,8 +121,7 @@ func TestGatewaySubdomains(t *testing.T) {
 			"ensure /ipfs/ namespace is not mounted on subdomain",
 			URL("%s://%s.ipfs.%s/ipfs/%s", u.Scheme, CIDv1, u.Host, CIDv1),
 			Expect().
-				Status(404).
-				Response(),
+				Status(404),
 		))
 
 		with(testGatewayWithManyProtocols(t,
@@ -133,8 +130,7 @@ func TestGatewaySubdomains(t *testing.T) {
 			URL("%s://%s.ipfs.%s/ipfs/file.txt", u.Scheme, DirCID, u.Host),
 			Expect().
 				Status(200).
-				Body(Contains("I am a txt file")).
-				Response(),
+				Body(Contains("I am a txt file")),
 		))
 
 		with(testGatewayWithManyProtocols(t,
@@ -147,8 +143,7 @@ func TestGatewaySubdomains(t *testing.T) {
 					// TODO: implement html expectations
 					Contains("<a href=\"/hello\">hello</a>"),
 					Contains("<a href=\"/ipfs\">ipfs</a>"),
-				)).
-				Response(),
+				)),
 		))
 
 		with(testGatewayWithManyProtocols(t,
@@ -161,8 +156,7 @@ func TestGatewaySubdomains(t *testing.T) {
 					// TODO: implement html expectations
 					Contains("<a href=\"/ipfs/ipns/..\">..</a>"),
 					Contains("<a href=\"/ipfs/ipns/bar\">bar</a>"),
-				)).
-				Response(),
+				)),
 		))
 
 		with(testGatewayWithManyProtocols(t,
@@ -171,8 +165,7 @@ func TestGatewaySubdomains(t *testing.T) {
 			URL("%s://%s.ipfs.%s/ipfs/ipns/bar", u.Scheme, DirCID, u.Host),
 			Expect().
 				Status(200).
-				Body(Contains("text-file-content")).
-				Response(),
+				Body(Contains("text-file-content")),
 		))
 
 		with(testGatewayWithManyProtocols(t,
@@ -190,8 +183,7 @@ func TestGatewaySubdomains(t *testing.T) {
 						Contains("/ipfs/<a href=\"//%s/ipfs/%s\">%s</a>/<a href=\"//%s/ipfs/%s/ipfs\">ipfs</a>/<a href=\"//%s/ipfs/%s/ipfs/ipns\">ipns</a>",
 							u.Host, DirCID, DirCID, u.Host, DirCID, u.Host, DirCID),
 					),
-				).
-				Response(),
+				),
 		))
 
 		// TODO: # *.ipns.localhost
@@ -222,8 +214,7 @@ func TestGatewaySubdomains(t *testing.T) {
 			Expect().
 				Headers(
 					Header("Location").Equals("%s://%s.ipfs.%s/", u.Scheme, CIDv1, u.Host),
-				).
-				Response(),
+				),
 		))
 
 		with(testGatewayWithManyProtocols(t,
@@ -231,8 +222,7 @@ func TestGatewaySubdomains(t *testing.T) {
 			"error message should include original CID (and it should be case-sensitive, as we can't assume everyone uses base32)",
 			URL("%s://%s/ipfs/QmInvalidCID", u.Scheme, u.Host),
 			Expect().
-				Body(Contains("invalid path \"/ipfs/QmInvalidCID\"")).
-				Response(),
+				Body(Contains("invalid path \"/ipfs/QmInvalidCID\"")),
 		))
 
 		with(testGatewayWithManyProtocols(t,
@@ -243,8 +233,7 @@ func TestGatewaySubdomains(t *testing.T) {
 				Status(301).
 				Headers(
 					Header("Location").Equals("%s://%s.ipfs.%s/", u.Scheme, CIDv0to1, u.Host),
-				).
-				Response(),
+				),
 		))
 
 		with(testGatewayWithManyProtocols(t,
@@ -257,8 +246,7 @@ func TestGatewaySubdomains(t *testing.T) {
 				Status(301).
 				Headers(
 					Header("Location").Equals("https://%s.ipfs.%s/", CIDv1, u.Host),
-				).
-				Response(),
+				),
 		))
 
 		with(testGatewayWithManyProtocols(t,
@@ -273,8 +261,7 @@ func TestGatewaySubdomains(t *testing.T) {
 				Status(301).
 				Headers(
 					Header("Location").Equals("/ipfs/%s/wiki/Diego_Maradona.html", CIDWikipedia),
-				).
-				Response(),
+				),
 		))
 
 		// # example.com/ipns/<libp2p-key>
@@ -318,8 +305,7 @@ func TestGatewaySubdomains(t *testing.T) {
 			URL("%s/ipfs/%s", gatewayURL, CIDv1_TOO_LONG),
 			Expect().
 				Status(400).
-				Body(Contains("CID incompatible with DNS label length limit of 63")).
-				Response(),
+				Body(Contains("CID incompatible with DNS label length limit of 63")),
 		))
 
 		with(testGatewayWithManyProtocols(t,
@@ -328,8 +314,7 @@ func TestGatewaySubdomains(t *testing.T) {
 			URL("%s://%s.ipfs.%s/", u.Scheme, CIDv1_TOO_LONG, u.Host),
 			Expect().
 				Status(400).
-				Body(Contains("CID incompatible with DNS label length limit of 63")).
-				Response(),
+				Body(Contains("CID incompatible with DNS label length limit of 63")),
 		))
 
 		// # public subdomain gateway: *.example.com
@@ -353,8 +338,7 @@ func TestGatewaySubdomains(t *testing.T) {
 			"",
 			URL("%s://%s/ipfs/%s", u.Scheme, "fake.domain.com", CIDv1),
 			Expect().
-				Status(200).
-				Response(),
+				Status(200),
 		))
 
 		with(testGatewayWithManyProtocols(t,
@@ -367,8 +351,7 @@ func TestGatewaySubdomains(t *testing.T) {
 				Status(301).
 				Headers(
 					Header("Location").Equals("%s://%s.ipfs.%s/", u.Scheme, CIDv1, u.Host),
-				).
-				Response(),
+				),
 		))
 
 		with(testGatewayWithManyProtocols(t,
@@ -382,8 +365,7 @@ func TestGatewaySubdomains(t *testing.T) {
 				Status(301).
 				Headers(
 					Header("Location").Equals("https://%s.ipfs.%s/", CIDv1, u.Host),
-				).
-				Response(),
+				),
 		))
 	}
 
@@ -392,7 +374,7 @@ func TestGatewaySubdomains(t *testing.T) {
 	}
 }
 
-func testGatewayWithManyProtocols(t *testing.T, label string, hint string, reqURL interface{}, expected CResponse) []CTest {
+func testGatewayWithManyProtocols(t *testing.T, label string, hint string, reqURL interface{}, expected ExpectBuilder) []CTest {
 	t.Helper()
 
 	baseURL := ""
@@ -427,7 +409,7 @@ func testGatewayWithManyProtocols(t *testing.T, label string, hint string, reqUR
 	u.Host = GatewayHost
 	rawURL := u.String()
 
-	return []CTest{
+	return SugarTests{
 		{
 			Name: fmt.Sprintf("%s (direct HTTP)", label),
 			Hint: fmt.Sprintf("%s\n%s", hint, "direct HTTP request (hostname in URL, raw IP in Host header)"),
@@ -436,8 +418,7 @@ func testGatewayWithManyProtocols(t *testing.T, label string, hint string, reqUR
 				DoNotFollowRedirects().
 				Headers(
 					Header("Host", host),
-				).
-				Request(),
+				),
 			Response: expected,
 		},
 		{
@@ -446,8 +427,7 @@ func testGatewayWithManyProtocols(t *testing.T, label string, hint string, reqUR
 			Request: baseReq.
 				URL(baseURL).
 				Proxy(GatewayURL).
-				DoNotFollowRedirects().
-				Request(),
+				DoNotFollowRedirects(),
 			Response: expected,
 		},
 		{
@@ -464,9 +444,8 @@ func testGatewayWithManyProtocols(t *testing.T, label string, hint string, reqUR
 				DoNotFollowRedirects().
 				Headers(
 					Header("Host", host),
-				).
-				Request(),
+				),
 			Response: expected,
 		},
-	}
+	}.Build()
 }

--- a/tests/t0117_gateway_block_test.go
+++ b/tests/t0117_gateway_block_test.go
@@ -1,93 +1,91 @@
 package tests
 
 import (
-	"fmt"
 	"strconv"
 	"strings"
 	"testing"
 
 	"github.com/ipfs/gateway-conformance/tooling/car"
-	. "github.com/ipfs/gateway-conformance/tooling/check"
 	. "github.com/ipfs/gateway-conformance/tooling/test"
 )
 
 func TestGatewayBlock(t *testing.T) {
 	fixture := car.MustOpenUnixfsCar("t0117-gateway-block.car")
-	tests := []CTest{
+	tests := SugarTests{
 		{
 			Name: "GET with format=raw param returns a raw block",
-			Request: CRequest{
-				Path: fmt.Sprintf("ipfs/%s/dir?format=raw", fixture.MustGetCid()),
-			},
-			Response: CResponse{
-				StatusCode: 200,
-				Body:       fixture.MustGetRawData("dir"),
-			},
+			Request: Request().
+				Path("ipfs/%s/dir", fixture.MustGetCid()).
+				Query("format", "raw"),
+			Response: Expect().
+				Status(200).
+				Body(fixture.MustGetRawData("dir")),
 		},
 		{
 			Name: "GET with application/vnd.ipld.raw header returns a raw block",
-			Request: CRequest{
-				Path: fmt.Sprintf("ipfs/%s/dir", fixture.MustGetCid()),
-				Headers: map[string]string{
-					"Accept": "application/vnd.ipld.raw",
-				},
-			},
-			Response: CResponse{
-				StatusCode: 200,
-				Body:       fixture.MustGetRawData("dir"),
-			},
+			Request: Request().
+				Path("ipfs/%s/dir", fixture.MustGetCid()).
+				Headers(
+					Header("Accept", "application/vnd.ipld.raw"),
+				),
+			Response: Expect().
+				Status(200).
+				Body(fixture.MustGetRawData("dir")),
 		},
 		{
 			Name: "GET with application/vnd.ipld.raw header returns expected response headers",
-			Request: CRequest{
-				Path: fmt.Sprintf("ipfs/%s/dir/ascii.txt", fixture.MustGetCid()),
-				Headers: map[string]string{
-					"Accept": "application/vnd.ipld.raw",
-				},
-			},
-			Response: CResponse{
-				StatusCode: 200,
-				Headers: map[string]interface{}{
-					"Content-Type":           "application/vnd.ipld.raw",
-					"Content-Length":         IsEqual("%d", len(fixture.MustGetRawData("dir", "ascii.txt"))),
-					"Content-Disposition":    Matches("attachment;\\s*filename=\"%s\\.bin", fixture.MustGetCid("dir", "ascii.txt")),
-					"X-Content-Type-Options": "nosniff",
-				},
-				Body: fixture.MustGetRawData("dir", "ascii.txt"),
-			},
+			Request: Request().
+				Path("ipfs/%s/dir/ascii.txt", fixture.MustGetCid()).
+				Headers(
+					Header("Accept", "application/vnd.ipld.raw"),
+				),
+			Response: Expect().
+				Status(200).
+				Headers(
+					Header("Content-Type").
+						Equals("application/vnd.ipld.raw"),
+					Header("Content-Length").
+						Equals("%d", len(fixture.MustGetRawData("dir", "ascii.txt"))),
+					Header("Content-Disposition").
+						Matches("attachment;\\s*filename=\"%s\\.bin", fixture.MustGetCid("dir", "ascii.txt")),
+					Header("X-Content-Type-Options").
+						Equals("nosniff"),
+				).
+				Body(fixture.MustGetRawData("dir", "ascii.txt")),
 		},
 		{
-			Name: "GET with application/vnd.ipld.raw header and filename param returns expected Content-Disposition header",
-			Request: CRequest{
-				Path: fmt.Sprintf("ipfs/%s/dir/ascii.txt?filename=foobar.bin", fixture.MustGetCid()),
-				Headers: map[string]string{
-					"Accept": "application/vnd.ipld.raw",
-				},
-			},
-			Response: CResponse{
-				StatusCode: 200,
-				Headers: map[string]interface{}{
-					"Content-Disposition": Matches("attachment;\\s*filename=\"foobar\\.bin"),
-				},
-			},
+			Name: "GET with application/vnd.ipld.raw header and filename param returns expected Content-Disposition header with custom filename",
+			Request: Request().
+				Path("ipfs/%s/dir/ascii.txt?filename=foobar.bin", fixture.MustGetCid()).
+				Headers(
+					Header("Accept", "application/vnd.ipld.raw"),
+				),
+			Response: Expect().
+				Status(200).
+				Headers(
+					Header("Content-Disposition").
+						Matches("attachment;\\s*filename=\"foobar\\.bin"),
+				),
 		},
 		{
 			Name: "GET with application/vnd.ipld.raw header returns expected caching headers",
-			Request: CRequest{
-				Path: fmt.Sprintf("ipfs/%s/dir/ascii.txt", fixture.MustGetCid()),
-				Headers: map[string]string{
-					"Accept": "application/vnd.ipld.raw",
-				},
-			},
-			Response: CResponse{
-				StatusCode: 200,
-				Headers: map[string]interface{}{
-					"ETag":         IsEqual("\"%s.raw\"", fixture.MustGetCid("dir", "ascii.txt")),
-					"X-IPFS-Path":  IsEqual("/ipfs/%s/dir/ascii.txt", fixture.MustGetCid()),
-					"X-IPFS-Roots": Contains(fixture.MustGetCid()),
-					"Cache-Control": Checks(
-						"It should be public, immutable and have max-age of at least 31536000.",
-						func(v string) bool {
+			Request: Request().
+				Path("ipfs/%s/dir/ascii.txt", fixture.MustGetCid()).
+				Headers(
+					Header("Accept", "application/vnd.ipld.raw"),
+				),
+			Response: Expect().
+				Status(200).
+				Headers(
+					Header("ETag").
+						Equals("\"%s.raw\"", fixture.MustGetCid("dir", "ascii.txt")),
+					Header("X-IPFS-Path").
+						Equals("/ipfs/%s/dir/ascii.txt", fixture.MustGetCid()),
+					Header("X-IPFS-Roots").
+						Contains(fixture.MustGetCid()),
+					Header("Cache-Control").
+						Hint("It should be public, immutable and have max-age of at least 31536000.").
+						Checks(func(v string) bool {
 							directives := strings.Split(strings.ReplaceAll(v, " ", ""), ",")
 							dir := make(map[string]string)
 							for _, directive := range directives {
@@ -116,12 +114,10 @@ func TestGatewayBlock(t *testing.T) {
 								return false
 							}
 							return true
-						},
-					),
-				},
-			},
+						}),
+				),
 		},
-	}
+	}.Build()
 
 	Run(t, tests)
 }

--- a/tests/t0118_gateway_car_test.go
+++ b/tests/t0118_gateway_car_test.go
@@ -1,7 +1,6 @@
 package tests
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/ipfs/gateway-conformance/tooling/car"
@@ -12,42 +11,14 @@ import (
 func TestGatewayCar(t *testing.T) {
 	fixture := car.MustOpenUnixfsCar("t0118-test-dag.car")
 
-	// CAR stream is not deterministic, as blocks can arrive in random order,
-	// but if we have a small file that fits into a single block, and export its CID
-	// we will get a CAR that is a deterministic array of bytes.
 	tests := []CTest{
 		{
 			Name: "GET response for application/vnd.ipld.car",
-			// Test between l85 and l112
-			Request: CRequest{
-				Path: fmt.Sprintf("ipfs/%s/subdir/ascii.txt", fixture.MustGetCid()),
-				Headers: map[string]string{
-					"Accept": "application/vnd.ipld.car",
-				},
-			},
-			Response: CResponse{
-				StatusCode: 200,
-				Headers: map[string]interface{}{
-					"Content-Type": ContainsWithHint(
-						"Expected content type to be application/vnd.ipld.car",
-						"application/vnd.ipld.car",
-					),
-					"Content-Length": IsEmpty(
-						"CAR is streamed, gateway may not have the entire thing, unable to calculate total size"),
-					"Content-Disposition": ContainsWithHint(
-						"Expected content disposition to be attachment; filename=\"<cid>.car\"",
-						"attachment\\; filename=\"%s.car\"", fixture.MustGetCid("subdir", "ascii.txt")),
-					"X-Content-Type-Options": IsEqual("nosniff"),
-					"Accept-Ranges": IsEqualWithHint(
-						"CAR is streamed, gateway may not have the entire thing, unable to support range-requests. Partial downloads and resumes should be handled using IPLD selectors: https://github.com/ipfs/go-ipfs/issues/8769",
-						"none",
-					),
-				},
-			},
-		},
-		{
-			// Test between l85 and l112
-			Name: "GET response for application/vnd.ipld.car2",
+			Hint: `
+				CAR stream is not deterministic, as blocks can arrive in random order,
+				but if we have a small file that fits into a single block, and export its CID
+				we will get a CAR that is a deterministic array of bytes.
+			`,
 			Request: Request().
 				Path("ipfs/%s/subdir/ascii.txt", fixture.MustGetCid()).
 				Headers(

--- a/tests/t0118_gateway_car_test.go
+++ b/tests/t0118_gateway_car_test.go
@@ -4,14 +4,13 @@ import (
 	"testing"
 
 	"github.com/ipfs/gateway-conformance/tooling/car"
-	. "github.com/ipfs/gateway-conformance/tooling/check"
 	. "github.com/ipfs/gateway-conformance/tooling/test"
 )
 
 func TestGatewayCar(t *testing.T) {
 	fixture := car.MustOpenUnixfsCar("t0118-test-dag.car")
 
-	tests := []CTest{
+	tests := SugarTests{
 		{
 			Name: "GET response for application/vnd.ipld.car",
 			Hint: `
@@ -23,7 +22,7 @@ func TestGatewayCar(t *testing.T) {
 				Path("ipfs/%s/subdir/ascii.txt", fixture.MustGetCid()).
 				Headers(
 					Header("Accept", "application/vnd.ipld.car"),
-				).Request(),
+				),
 			Response: Expect().
 				Status(200).
 				Headers(
@@ -42,9 +41,9 @@ func TestGatewayCar(t *testing.T) {
 					Header("Accept-Ranges").
 						Hint("CAR is streamed, gateway may not have the entire thing, unable to support range-requests. Partial downloads and resumes should be handled using IPLD selectors: https://github.com/ipfs/go-ipfs/issues/8769").
 						Equals("none"),
-				).Response(),
+				),
 		},
-	}
+	}.Build()
 
 	Run(t, tests)
 }

--- a/tooling/check/check.go
+++ b/tooling/check/check.go
@@ -182,7 +182,7 @@ func Checks[T any](hint string, f func(T) bool) CheckWithHint[T] {
 	})
 }
 
-func (c *CheckFunc[T]) Check(v T) CheckOutput {
+func (c CheckFunc[T]) Check(v T) CheckOutput {
 	if c.Fn(v) {
 		return CheckOutput{
 			Success: true,

--- a/tooling/test/sugar.go
+++ b/tooling/test/sugar.go
@@ -202,7 +202,7 @@ func Header(key string, opts ...string) HeaderBuilder {
 		panic("too many options")
 	}
 	if len(opts) > 0 {
-		return HeaderBuilder{Key: key, Value: opts[0]}
+		return HeaderBuilder{Key: key, Value: opts[0], Check: check.IsEqual(opts[0])}
 	}
 
 	return HeaderBuilder{Key: key}
@@ -210,6 +210,11 @@ func Header(key string, opts ...string) HeaderBuilder {
 
 func (h HeaderBuilder) Contains(value string, rest ...any) HeaderBuilder {
 	h.Check = check.Contains(value, rest...)
+	return h
+}
+
+func (h HeaderBuilder) Matches(value string, rest ...any) HeaderBuilder {
+	h.Check = check.Matches(value, rest...)
 	return h
 }
 
@@ -225,5 +230,12 @@ func (h HeaderBuilder) Equals(value string, args ...any) HeaderBuilder {
 
 func (h HeaderBuilder) IsEmpty() HeaderBuilder {
 	h.Check = check.CheckIsEmpty{}
+	return h
+}
+
+func (h HeaderBuilder) Checks(f func(string) bool) HeaderBuilder {
+	h.Check = check.CheckFunc[string]{
+		Fn: f,
+	}
 	return h
 }

--- a/tooling/test/sugar.go
+++ b/tooling/test/sugar.go
@@ -124,6 +124,11 @@ func (e ExpectBuilder) Header(h HeaderBuilder) ExpectBuilder {
 	return e
 }
 
+func (e ExpectBuilder) Bytes(body string) ExpectBuilder {
+	e.Body_ = []byte(body)
+	return e
+}
+
 func (e ExpectBuilder) Headers(hs ...HeaderBuilder) ExpectBuilder {
 	e.Headers_ = append(e.Headers_, hs...)
 	return e

--- a/tooling/test/test.go
+++ b/tooling/test/test.go
@@ -37,6 +37,28 @@ type CTest struct {
 	Response CResponse `json:"response,omitempty"`
 }
 
+type SugarTest struct {
+	Name     string
+	Hint     string
+	Request  RequestBuilder
+	Response ExpectBuilder
+}
+
+type SugarTests []SugarTest
+
+func (s SugarTests) Build() []CTest {
+	var tests []CTest
+	for _, test := range s {
+		tests = append(tests, CTest{
+			Name:     test.Name,
+			Hint:     test.Hint,
+			Request:  test.Request.Request(),
+			Response: test.Response.Response(),
+		})
+	}
+	return tests
+}
+
 func Run(t *testing.T, tests []CTest) {
 	// NewDialer()
 


### PR DESCRIPTION
- [x] move every test to sugar API
- [x] implement missing features
- [x] implement `SugarTests`, top-level sugar, so that we don't have to repeat all the `.Responses()` clause.