### PR TITLE
ci: automate release process of gateway-conformance

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,58 @@
+name: Docker
+on:
+  workflow_dispatch:
+    inputs:
+      tags:
+        description: 'Comma separated list of tags to apply to the image.'
+        required: false
+      artifacts-url:
+        description: |
+          The URL of the artifacts to download.
+          If provided, we'll try to retrieve the tags from the release.json file of the release artifact.
+        required: false
+  workflow_call:
+
+jobs:
+  tags:
+    runs-on: ubuntu-latest
+    outputs:
+      tags: ${{ fromJSON(steps.workflow-run.outputs.artifacts)['release'].files['release.json'].tags || github.event.inputs.tags }}
+    steps:
+      # This step will download the release artifact either from the workflow
+      # run that triggered this workflow or from the artifacts-url input. It
+      # will also parse the release.json file.
+      - id: workflow-run
+        if: github.event.workflow_run.artifacts_url != '' || github.event.inputs.artifacts-url != ''
+        uses: pl-strflt/rich-workflow-run@v1
+        with:
+          artifacts-url: ${{ github.event.workflow_run.artifacts_url || github.event.inputs.artifacts-url }}
+          artifact-names: release
+  docker:
+    needs: [tags]
+    if: needs.tags.outputs.tags != ''
+    name: Docker
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      contents: read
+    steps:
+      # This step will add ghcr.io/<repository> prefix to each <tag>.
+      - id: tags
+        env:
+          REPOSITORY: ${{ github.repository }}
+          TAGS: ${{ needs.tags.outputs.tags }}
+        run: jq -Rr 'split(",") | map(gsub("^\\s+|\\s+$";"") | "ghcr.io/\(env.REPOSITORY):\(.)") | join(",") | "tags=\(.)"' <<< "$TAGS" >> $GITHUB_OUTPUT
+      - uses: actions/checkout@v3
+      - uses: docker/setup-qemu-action@v2
+      - uses: docker/setup-buildx-action@v2
+      - uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
+      - uses: docker/build-push-action@v4
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.tags.outputs.tags }}

--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -1,4 +1,4 @@
-name: Docker
+name: Release Docker
 on:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ on:
     branches: [main]
 jobs:
   release:
-    name: Realase
+    name: Release
     runs-on: ubuntu-latest
     steps:
       - id: release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,31 +1,43 @@
-name: Docker
+name: Release
 on:
-  workflow_dispatch:
-    inputs:
-      tag:
-        description: 'Tag'
-        required: true
-        default: 'latest'
+  push:
+    paths: [CHANGELOG.md]
+    branches: [main]
+  pull_request:
+    paths: [CHANGELOG.md]
+    branches: [main]
 jobs:
-  docker:
-    name: Docker
+  release:
+    name: Realase
     runs-on: ubuntu-latest
-    permissions:
-      packages: write
-      contents: read
     steps:
-      - uses: actions/checkout@v3
-      - uses: docker/setup-qemu-action@v2
-      - uses: docker/setup-buildx-action@v2
-      - uses: docker/login-action@v2
+      - id: release
+        uses: pl-strflt/changelog-driven-release@v1
         with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ github.token }}
-      - uses: docker/build-push-action@v4
+          path: CHANGELOG.md
+          draft: ${{ github.event_name == 'pull_request' }}
+      - if: github.event_name == 'pull_request' && steps.release.outputs.tag != ''
+        uses: marocchino/sticky-pull-request-comment@3d60a5b2dae89d44e0c6ddc69dd7536aec2071cd # v2.5.0
         with:
-          context: .
-          platforms: linux/amd64,linux/arm64
-          push: true
-          tags: |
-            ghcr.io/${{ github.repository }}:${{ github.event.inputs.tag || 'latest' }}
+          header: release
+          recreate: true
+          message: |
+            ## [${{ steps.release.outputs.tag }}](${{ steps.release.outputs.url }})
+
+            ${{ steps.release.outputs.body }}
+      - if: github.event_name != 'pull_request' && steps.release.outputs.tag != ''
+        env:
+          RELEASE: |
+            {
+              "tag": "${{ steps.release.outputs.tag }}",
+              "tags": "${{ steps.release.outputs.tags }}",
+              "body": "${{ steps.release.outputs.body }}",
+              "url": "${{ steps.release.outputs.url }}",
+              "draft": false
+            }
+        run: jq -n "$RELEASE" > release.json
+      - if: github.event_name != 'pull_request' && steps.release.outputs.tag != ''
+        uses: actions/upload-artifact@v3
+        with:
+          name: release
+          path: release.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## Unreleased
+### Added
+- v1 of the Gateway Conformance test suite


### PR DESCRIPTION
This PR sets up CHANGELOG driven releases for this repo. This will take care of creating GitHub Releases and tags.

It also modifies the Docker release set up so that we create Docker images whenever we publish a release.

Most of the testing will happen post-merge when we try to do the release.