### PR TITLE
wip: feat/t0116 gateway cache.sh

### DIFF
--- a/tests/t0113_gateway_symlink_test.go
+++ b/tests/t0113_gateway_symlink_test.go
@@ -11,24 +11,22 @@ import (
 func TestGatewaySymlink(t *testing.T) {
 	fixture := car.MustOpenUnixfsCar("t0113-gateway-symlink.car")
 
-	tests := []CTest{
+	tests := SugarTests{
 		{
 			Name: "Test the directory listing",
 			Request: Request().
-				Path("ipfs/%s?format=raw", fixture.MustGetCid()).Request(),
+				Path("ipfs/%s?format=raw", fixture.MustGetCid()),
 			Response: Expect().
 				Status(200).
-				Body(fixture.MustGetRawData()).
-				Response(),
+				Body(fixture.MustGetRawData()),
 		},
 		{
 			Name: "Test the symlink",
 			Request: Request().
-				Path("ipfs/%s/bar", fixture.MustGetCid()).Request(),
+				Path("ipfs/%s/bar", fixture.MustGetCid()),
 			Response: Expect().
 				Status(200).
-				Bytes("foo").
-				Response(),
+				Bytes("foo"),
 		},
 	}
 

--- a/tests/t0114_gateway_subdomains_test.go
+++ b/tests/t0114_gateway_subdomains_test.go
@@ -22,10 +22,10 @@ func TestGatewaySubdomains(t *testing.T) {
 	CIDv1_TOO_LONG := fixture.MustGetCid("hello-CIDv1_TOO_LONG")
 	CIDWikipedia := "QmXoypizjW3WknFiJnKLwHCnL72vedxjQkDDP1mXWo6uco"
 
-	tests := []CTest{}
+	tests := SugarTests{}
 
 	// sugar: readable way to add more tests
-	with := func(moreTests []CTest) {
+	with := func(moreTests SugarTests) {
 		tests = append(tests, moreTests...)
 	}
 
@@ -64,7 +64,7 @@ func TestGatewaySubdomains(t *testing.T) {
 					We return body with HTTP 301 so existing cli scripts that use path-based
 					gateway do not break (curl doesn't auto-redirect without passing -L; wget
 					does not span across hostnames by default)
-					Context: https://github.com/ipfs/go-ipfs/issues/6975					
+					Context: https://github.com/ipfs/go-ipfs/issues/6975
 				`,
 					IsEqual("hello\n"),
 				),
@@ -374,7 +374,7 @@ func TestGatewaySubdomains(t *testing.T) {
 	}
 }
 
-func testGatewayWithManyProtocols(t *testing.T, label string, hint string, reqURL interface{}, expected ExpectBuilder) []CTest {
+func testGatewayWithManyProtocols(t *testing.T, label string, hint string, reqURL interface{}, expected ExpectBuilder) SugarTests {
 	t.Helper()
 
 	baseURL := ""
@@ -447,5 +447,5 @@ func testGatewayWithManyProtocols(t *testing.T, label string, hint string, reqUR
 				),
 			Response: expected,
 		},
-	}.Build()
+	}
 }

--- a/tests/t0116_gateway_cache_test.go
+++ b/tests/t0116_gateway_cache_test.go
@@ -198,91 +198,91 @@ func TestGatewayCache(t *testing.T) {
 		},
 		// The tests below require `ipnsId` to be set.
 		/*
-		{
-			Name: "GET for /ipns/ unixfs dir listing succeeds",
-			Request: Request().
-				Path("ipns/%s/root2/root3/", ipnsId),
-			Response: Expect().
-				Status(200).
-				Headers(
-					Header("Cache-Control").
-						IsEmpty(),
-					Header("X-Ipfs-Path").
-						Equals("/ipns/%s/root2/root3", ipnsId),
-					Header("X-Ipfs-Roots").
-						Equals("%s,%s,%s", fixture.MustGetCid(), fixture.MustGetCid("root2"), fixture.MustGetCid("root2", "root3")),
-					Header("Etag").
-						Matches("DirIndex-.*_CID-%s", fixture.MustGetCid("root2", "root3")),
-				),
-		},
-		{
-			Name: "GET for /ipns/ unixfs dir with index.html succeeds",
-			Request: Request().
-				Path("ipns/%s/root2/root3/root4/", ipnsId),
-			Response: Expect().
-				Status(200).
-				Headers(
-					Header("Cache-Control").
-						IsEmpty(),
-					Header("X-Ipfs-Path").
-						Equals("/ipns/%s/root2/root3/root4/", ipnsId),
-					Header("X-Ipfs-Roots").
-						Equals("%s,%s,%s,%s", fixture.MustGetCid(), fixture.MustGetCid("root2"), fixture.MustGetCid("root2", "root3"), fixture.MustGetCid("root2", "root3", "root4")),
-					Header("Etag").
-						Matches("DirIndex-.*_CID-%s", fixture.MustGetCid("root2", "root3", "root4")),
-				),
-		},
-		{
-			Name: "GET for /ipns/ unixfs file succeeds",
-			Request: Request().
-				Path("ipns/%s/root2/root3/root4/index.html", ipnsId),
-			Response: Expect().
-				Status(200).
-				Headers(
-					Header("Cache-Control").
-						Equals("public, max-age=29030400, immutable"),
-					Header("X-Ipfs-Path").
-						Equals("/ipns/%s/root2/root3/root4/index.html", ipnsId),
-					Header("X-Ipfs-Roots").
-						Equals("%s,%s,%s,%s,%s", fixture.MustGetCid(), fixture.MustGetCid("root2"), fixture.MustGetCid("root2", "root3"), fixture.MustGetCid("root2", "root3", "root4"), fixture.MustGetCid("root2", "root3", "root4", "index.html")),
-					Header("Etag").
-						Equals("\"%s\"", fixture.MustGetCid("root2", "root3", "root4", "index.html")),
-				),
-		},
-		{
-			Name: "GET for /ipns/ unixfs dir as DAG-JSON succeeds",
-			Request: Request().
-				Path("ipns/%s/root2/root3/root4/", ipnsId).
-				Query("format", "dag-json"),
-			Response: Expect().
-				Status(200).
-				Headers(
-					Header("Cache-Control").
-						Equals("public, max-age=29030400, immutable"),
-				),
-		},
-		{
-			Name: "GET for /ipns/ unixfs dir as JSON succeeds",
-			Request: Request().
-				Path("ipns/%s/root2/root3/root4/", ipnsId).
-				Query("format", "json"),
-			Response: Expect().
-				Status(200).
-				Headers(
-					Header("Cache-Control").
-						Equals("public, max-age=29030400, immutable"),
-				),
-		},
-		{
-			Name: "GET for /ipns/ file with matching Etag in If-None-Match returns 304 Not Modified",
-			Request: Request().
-				Path("ipns/%s/root2/root3/root4/index.html", ipnsId).
-				Headers(
-					Header("If-None-Match", fmt.Sprintf("\"%s\"", fixture.MustGetCid("root2", "root3", "root4", "index.html"))),
-				),
-			Response: Expect().
-				Status(304),
-		},
+			{
+				Name: "GET for /ipns/ unixfs dir listing succeeds",
+				Request: Request().
+					Path("ipns/%s/root2/root3/", ipnsId),
+				Response: Expect().
+					Status(200).
+					Headers(
+						Header("Cache-Control").
+							IsEmpty(),
+						Header("X-Ipfs-Path").
+							Equals("/ipns/%s/root2/root3", ipnsId),
+						Header("X-Ipfs-Roots").
+							Equals("%s,%s,%s", fixture.MustGetCid(), fixture.MustGetCid("root2"), fixture.MustGetCid("root2", "root3")),
+						Header("Etag").
+							Matches("DirIndex-.*_CID-%s", fixture.MustGetCid("root2", "root3")),
+					),
+			},
+			{
+				Name: "GET for /ipns/ unixfs dir with index.html succeeds",
+				Request: Request().
+					Path("ipns/%s/root2/root3/root4/", ipnsId),
+				Response: Expect().
+					Status(200).
+					Headers(
+						Header("Cache-Control").
+							IsEmpty(),
+						Header("X-Ipfs-Path").
+							Equals("/ipns/%s/root2/root3/root4/", ipnsId),
+						Header("X-Ipfs-Roots").
+							Equals("%s,%s,%s,%s", fixture.MustGetCid(), fixture.MustGetCid("root2"), fixture.MustGetCid("root2", "root3"), fixture.MustGetCid("root2", "root3", "root4")),
+						Header("Etag").
+							Matches("DirIndex-.*_CID-%s", fixture.MustGetCid("root2", "root3", "root4")),
+					),
+			},
+			{
+				Name: "GET for /ipns/ unixfs file succeeds",
+				Request: Request().
+					Path("ipns/%s/root2/root3/root4/index.html", ipnsId),
+				Response: Expect().
+					Status(200).
+					Headers(
+						Header("Cache-Control").
+							Equals("public, max-age=29030400, immutable"),
+						Header("X-Ipfs-Path").
+							Equals("/ipns/%s/root2/root3/root4/index.html", ipnsId),
+						Header("X-Ipfs-Roots").
+							Equals("%s,%s,%s,%s,%s", fixture.MustGetCid(), fixture.MustGetCid("root2"), fixture.MustGetCid("root2", "root3"), fixture.MustGetCid("root2", "root3", "root4"), fixture.MustGetCid("root2", "root3", "root4", "index.html")),
+						Header("Etag").
+							Equals("\"%s\"", fixture.MustGetCid("root2", "root3", "root4", "index.html")),
+					),
+			},
+			{
+				Name: "GET for /ipns/ unixfs dir as DAG-JSON succeeds",
+				Request: Request().
+					Path("ipns/%s/root2/root3/root4/", ipnsId).
+					Query("format", "dag-json"),
+				Response: Expect().
+					Status(200).
+					Headers(
+						Header("Cache-Control").
+							Equals("public, max-age=29030400, immutable"),
+					),
+			},
+			{
+				Name: "GET for /ipns/ unixfs dir as JSON succeeds",
+				Request: Request().
+					Path("ipns/%s/root2/root3/root4/", ipnsId).
+					Query("format", "json"),
+				Response: Expect().
+					Status(200).
+					Headers(
+						Header("Cache-Control").
+							Equals("public, max-age=29030400, immutable"),
+					),
+			},
+			{
+				Name: "GET for /ipns/ file with matching Etag in If-None-Match returns 304 Not Modified",
+				Request: Request().
+					Path("ipns/%s/root2/root3/root4/index.html", ipnsId).
+					Headers(
+						Header("If-None-Match", fmt.Sprintf("\"%s\"", fixture.MustGetCid("root2", "root3", "root4", "index.html"))),
+					),
+				Response: Expect().
+					Status(304),
+			},
 		*/
 		{
 			Name: "GET for /ipfs/ dir listing responds with Etag",
@@ -292,7 +292,7 @@ func TestGatewayCache(t *testing.T) {
 				Status(200).
 				Headers(
 					Header("Etag").
-						Checks(func (v string) bool {
+						Checks(func(v string) bool {
 							etag = v
 							return v != ""
 						}),
@@ -317,7 +317,7 @@ func TestGatewayCache(t *testing.T) {
 				Path("ipfs/%s/root2/root3/", fixture.MustGetCid()).
 				Headers(
 					Header("If-None-Match").
-						ValueFromFunc(func () string {
+						ValueFromFunc(func() string {
 							return fmt.Sprintf("W/%s", etag)
 						}),
 				),

--- a/tests/t0116_gateway_cache_test.go
+++ b/tests/t0116_gateway_cache_test.go
@@ -1,11 +1,9 @@
 package tests
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/ipfs/gateway-conformance/tooling/car"
-	. "github.com/ipfs/gateway-conformance/tooling/check"
 	. "github.com/ipfs/gateway-conformance/tooling/test"
 )
 
@@ -16,197 +14,193 @@ import (
 func TestGatewayCache(t *testing.T) {
 	fixture := car.MustOpenUnixfsCar("t0116-gateway-cache.car")
 
-	tests := []CTest{
+	tests := SugarTests{
 		{
 			Name: "GET for /ipfs/ unixfs dir listing succeeds",
-			Request: CRequest{
-				Path: fmt.Sprintf("ipfs/%s/root2/root3/", fixture.MustGetCid()),
-			},
-			Response: CResponse{
-				StatusCode: 200,
-				Headers: map[string]interface{}{
-					"Cache-Control": IsEmpty(),
-					"X-Ipfs-Path":   IsEqual("/ipfs/%s/root2/root3/", fixture.MustGetCid()),
-					"X-Ipfs-Roots":  IsEqual("%s,%s,%s", fixture.MustGetCid(), fixture.MustGetCid("root2"), fixture.MustGetCid("root2", "root3")),
-					"Etag":          Matches("DirIndex-.*_CID-%s", fixture.MustGetCid("root2", "root3")),
-				},
-			},
+			Request: Request().
+				Path("ipfs/%s/root2/root3/", fixture.MustGetCid()),
+			Response: Expect().
+				Status(200).
+				Headers(
+					Header("Cache-Control").
+						IsEmpty(),
+					Header("X-Ipfs-Path").
+						Equals("/ipfs/%s/root2/root3/", fixture.MustGetCid()),
+					Header("X-Ipfs-Roots").
+						Equals("%s,%s,%s", fixture.MustGetCid(), fixture.MustGetCid("root2"), fixture.MustGetCid("root2", "root3")),
+					Header("Etag").
+						Matches("DirIndex-.*_CID-%s", fixture.MustGetCid("root2", "root3")),
+				),
 		},
 		{
 			Name: "GET for /ipfs/ unixfs dir with index.html succeeds",
-			Request: CRequest{
-				Path: fmt.Sprintf("ipfs/%s/root2/root3/root4/", fixture.MustGetCid()),
-			},
-			Response: CResponse{
-				StatusCode: 200,
-				Headers: map[string]interface{}{
-					"Cache-Control": "public, max-age=29030400, immutable",
-					"X-Ipfs-Path":   IsEqual("/ipfs/%s/root2/root3/root4/", fixture.MustGetCid()),
-					"X-Ipfs-Roots":  IsEqual("%s,%s,%s,%s", fixture.MustGetCid(), fixture.MustGetCid("root2"), fixture.MustGetCid("root2", "root3"), fixture.MustGetCid("root2", "root3", "root4")),
-					"Etag":          IsEqual("\"%s\"", fixture.MustGetCid("root2", "root3", "root4")),
-				},
-			},
+			Request: Request().
+				Path("ipfs/%s/root2/root3/root4/", fixture.MustGetCid()),
+			Response: Expect().
+				Status(200).
+				Headers(
+					Header("Cache-Control").
+						Equals("public, max-age=29030400, immutable"),
+					Header("X-Ipfs-Path").
+						Equals("/ipfs/%s/root2/root3/root4/", fixture.MustGetCid()),
+					Header("X-Ipfs-Roots").
+						Equals("%s,%s,%s,%s", fixture.MustGetCid(), fixture.MustGetCid("root2"), fixture.MustGetCid("root2", "root3"), fixture.MustGetCid("root2", "root3", "root4")),
+					Header("Etag").
+						Equals("\"%s\"", fixture.MustGetCid("root2", "root3", "root4")),
+				),
 		},
 		{
 			Name: "GET for /ipfs/ unixfs file succeeds",
-			Request: CRequest{
-				Path: fmt.Sprintf("ipfs/%s/root2/root3/root4/index.html", fixture.MustGetCid()),
-			},
-			Response: CResponse{
-				StatusCode: 200,
-				Headers: map[string]interface{}{
-					"Cache-Control": "public, max-age=29030400, immutable",
-					"X-Ipfs-Path":   IsEqual("/ipfs/%s/root2/root3/root4/index.html", fixture.MustGetCid()),
-					"X-Ipfs-Roots":  IsEqual("%s,%s,%s,%s,%s", fixture.MustGetCid(), fixture.MustGetCid("root2"), fixture.MustGetCid("root2", "root3"), fixture.MustGetCid("root2", "root3", "root4"), fixture.MustGetCid("root2", "root3", "root4", "index.html")),
-					"Etag":          IsEqual("\"%s\"", fixture.MustGetCid("root2", "root3", "root4", "index.html")),
-				},
-			},
+			Request: Request().
+				Path("ipfs/%s/root2/root3/root4/index.html", fixture.MustGetCid()),
+			Response: Expect().
+				Status(200).
+				Headers(
+					Header("Cache-Control").
+						Equals("public, max-age=29030400, immutable"),
+					Header("X-Ipfs-Path").
+						Equals("/ipfs/%s/root2/root3/root4/index.html", fixture.MustGetCid()),
+					Header("X-Ipfs-Roots").
+						Equals("%s,%s,%s,%s,%s", fixture.MustGetCid(), fixture.MustGetCid("root2"), fixture.MustGetCid("root2", "root3"), fixture.MustGetCid("root2", "root3", "root4"), fixture.MustGetCid("root2", "root3", "root4", "index.html")),
+					Header("Etag").
+						Equals("\"%s\"", fixture.MustGetCid("root2", "root3", "root4", "index.html")),
+				),
 		},
 		{
 			Name: "GET for /ipfs/ unixfs dir as DAG-JSON succeeds",
-			Request: CRequest{
-				Path: fmt.Sprintf("ipfs/%s/root2/root3/root4/?format=dag-json", fixture.MustGetCid()),
-			},
-			Response: CResponse{
-				StatusCode: 200,
-				Headers: map[string]interface{}{
-					"Cache-Control": "public, max-age=29030400, immutable",
-				},
-			},
+			Request: Request().
+				Path("ipfs/%s/root2/root3/root4/?format=dag-json", fixture.MustGetCid()),
+			Response: Expect().
+				Status(200).
+				Headers(
+					Header("Cache-Control").
+						Equals("public, max-age=29030400, immutable"),
+				),
 		},
 		{
 			Name: "GET for /ipfs/ unixfs dir as JSON succeeds",
-			Request: CRequest{
-				Path: fmt.Sprintf("ipfs/%s/root2/root3/root4/?format=json", fixture.MustGetCid()),
-			},
-			Response: CResponse{
-				StatusCode: 200,
-				Headers: map[string]interface{}{
-					"Cache-Control": "public, max-age=29030400, immutable",
-				},
-			},
+			Request: Request().
+				Path("ipfs/%s/root2/root3/root4/?format=json", fixture.MustGetCid()),
+			Response: Expect().
+				Status(200).
+				Headers(
+					Header("Cache-Control").
+						Equals("public, max-age=29030400, immutable"),
+				),
 		},
 		{
 			Name: "HEAD for /ipfs/ with only-if-cached succeeds when in local datastore",
-			Request: CRequest{
-				Path: fmt.Sprintf("ipfs/%s/root2/root3/root4/?format=json", fixture.MustGetCid()),
-				Headers: map[string]string{
-					"Cache-Control": "only-if-cached",
-				},
-				Method: "HEAD",
-			},
-			Response: CResponse{
-				StatusCode: 200,
-			},
+			Request: Request().
+				Path("ipfs/%s/root2/root3/root4/?format=json", fixture.MustGetCid()).
+				Headers(
+					Header("Cache-Control").
+						Equals("only-if-cached"),
+				).
+				Method("HEAD"),
+			Response: Expect().
+				Status(200),
 		},
 		{
 			Name: "HEAD for /ipfs/ with only-if-cached fails when not in local datastore",
-			Request: CRequest{
-				Path: "ipfs/QmYzfKSE55XCjD1MW128RfciAf2DViABhEiXfgVFMabSjN",
-				Headers: map[string]string{
-					"Cache-Control": "only-if-cached",
-				},
-				Method: "HEAD",
-			},
-			Response: CResponse{
-				StatusCode: 412,
-			},
+			Request: Request().
+				Path("ipfs/QmYzfKSE55XCjD1MW128RfciAf2DViABhEiXfgVFMabSjN").
+				Headers(
+					Header("Cache-Control").
+						Equals("only-if-cached"),
+				).
+				Method("HEAD"),
+			Response: Expect().
+				Status(412),
 		},
 		{
 			Name: "GET for /ipfs/ with only-if-cached succeeds when in local datastore",
-			Request: CRequest{
-				Path: fmt.Sprintf("ipfs/%s/root2/root3/root4/?format=json", fixture.MustGetCid()),
-				Headers: map[string]string{
-					"Cache-Control": "only-if-cached",
-				},
-			},
-			Response: CResponse{
-				StatusCode: 200,
-			},
+			Request: Request().
+				Path("ipfs/%s/root2/root3/root4/?format=json", fixture.MustGetCid()).
+				Headers(
+					Header("Cache-Control").
+						Equals("only-if-cached"),
+				),
+			Response: Expect().
+				Status(200),
 		},
 		{
 			Name: "GET for /ipfs/ with only-if-cached fails when not in local datastore",
-			Request: CRequest{
-				Path: "ipfs/QmYzfKSE55XCjD1MW128RfciAf2DViABhEiXfgVFMabSjN",
-				Headers: map[string]string{
-					"Cache-Control": "only-if-cached",
-				},
-			},
-			Response: CResponse{
-				StatusCode: 412,
-			},
+			Request: Request().
+				Path("ipfs/QmYzfKSE55XCjD1MW128RfciAf2DViABhEiXfgVFMabSjN").
+				Headers(
+					Header("Cache-Control").
+						Equals("only-if-cached"),
+				),
+			Response: Expect().
+				Status(412),
 		},
 		{
 			Name: "GET for /ipfs/ file with matching Etag in If-None-Match returns 304 Not Modified",
-			Request: CRequest{
-				Path: fmt.Sprintf("ipfs/%s/root2/root3/root4/index.html", fixture.MustGetCid()),
-				Headers: map[string]string{
-					"If-None-Match": fmt.Sprintf("\"%s\"", fixture.MustGetCid("root2", "root3", "root4", "index.html")),
-				},
-			},
-			Response: CResponse{
-				StatusCode: 304,
-			},
+			Request: Request().
+				Path("ipfs/%s/root2/root3/root4/index.html", fixture.MustGetCid()).
+				Headers(
+					Header("If-None-Match").
+						Equals("\"%s\"", fixture.MustGetCid("root2", "root3", "root4", "index.html")),
+				),
+			Response: Expect().
+				Status(304),
 		},
 		{
 			Name: "GET for /ipfs/ dir with index.html file with matching Etag in If-None-Match returns 304 Not Modified",
-			Request: CRequest{
-				Path: fmt.Sprintf("ipfs/%s/root2/root3/root4/", fixture.MustGetCid()),
-				Headers: map[string]string{
-					"If-None-Match": fmt.Sprintf("\"%s\"", fixture.MustGetCid("root2", "root3", "root4")),
-				},
-			},
-			Response: CResponse{
-				StatusCode: 304,
-			},
+			Request: Request().
+				Path("ipfs/%s/root2/root3/root4/", fixture.MustGetCid()).
+				Headers(
+					Header("If-None-Match").
+						Equals("\"%s\"", fixture.MustGetCid("root2", "root3", "root4")),
+				),
+			Response: Expect().
+				Status(304),
 		},
 		{
 			Name: "GET for /ipfs/ file with matching third Etag in If-None-Match returns 304 Not Modified",
-			Request: CRequest{
-				Path: fmt.Sprintf("ipfs/%s/root2/root3/root4/index.html", fixture.MustGetCid()),
-				Headers: map[string]string{
-					"If-None-Match": fmt.Sprintf("\"fakeEtag1\", \"fakeEtag2\", \"%s\"", fixture.MustGetCid("root2", "root3", "root4", "index.html")),
-				},
-			},
-			Response: CResponse{
-				StatusCode: 304,
-			},
+			Request: Request().
+				Path("ipfs/%s/root2/root3/root4/index.html", fixture.MustGetCid()).
+				Headers(
+					Header("If-None-Match").
+						Equals("\"fakeEtag1\", \"fakeEtag2\", \"%s\"", fixture.MustGetCid("root2", "root3", "root4", "index.html")),
+				),
+			Response: Expect().
+				Status(304),
 		},
 		{
 			Name: "GET for /ipfs/ file with matching weak Etag in If-None-Match returns 304 Not Modified",
-			Request: CRequest{
-				Path: fmt.Sprintf("ipfs/%s/root2/root3/root4/index.html", fixture.MustGetCid()),
-				Headers: map[string]string{
-					"If-None-Match": fmt.Sprintf("W/\"%s\"", fixture.MustGetCid("root2", "root3", "root4", "index.html")),
-				},
-			},
-			Response: CResponse{
-				StatusCode: 304,
-			},
-		}, {
-			Name: "GET for /ipfs/ file with wildcard Etag in If-None-Match returns 304 Not Modified",
-			Request: CRequest{
-				Path: fmt.Sprintf("ipfs/%s/root2/root3/root4/index.html", fixture.MustGetCid()),
-				Headers: map[string]string{
-					"If-None-Match": "*",
-				},
-			},
-			Response: CResponse{
-				StatusCode: 304,
-			},
-		}, {
-			Name: "GET for /ipfs/ dir listing with matching weak Etag in If-None-Match returns 304 Not Modified",
-			Request: CRequest{
-				Path: fmt.Sprintf("ipfs/%s/root2/root3/", fixture.MustGetCid()),
-				Headers: map[string]string{
-					"If-None-Match": fmt.Sprintf("W/\"%s\"", fixture.MustGetCid("root2", "root3")),
-				},
-			},
-			Response: CResponse{
-				StatusCode: 304,
-			},
+			Request: Request().
+				Path("ipfs/%s/root2/root3/root4/index.html", fixture.MustGetCid()).
+				Headers(
+					Header("If-None-Match").
+						Equals("W/\"%s\"", fixture.MustGetCid("root2", "root3", "root4", "index.html")),
+				),
+			Response: Expect().
+				Status(304),
 		},
-	}
+		{
+			Name: "GET for /ipfs/ file with wildcard Etag in If-None-Match returns 304 Not Modified",
+			Request: Request().
+				Path("ipfs/%s/root2/root3/root4/index.html", fixture.MustGetCid()).
+				Headers(
+					Header("If-None-Match").
+						Equals("*"),
+				),
+			Response: Expect().
+				Status(304),
+		},
+		{
+			Name: "GET for /ipfs/ dir listing with matching weak Etag in If-None-Match returns 304 Not Modified",
+			Request: Request().
+				Path("ipfs/%s/root2/root3/", fixture.MustGetCid()).
+				Headers(
+					Header("If-None-Match").
+						Equals("W/\"%s\"", fixture.MustGetCid("root2", "root3")),
+				),
+			Response: Expect().
+				Status(304),
+		},
+	}.Build()
 
 	Run(t, tests)
 }

--- a/tests/t0116_gateway_cache_test.go
+++ b/tests/t0116_gateway_cache_test.go
@@ -9,107 +9,90 @@ import (
 )
 
 /* TODO
-# GET /ipns/
-    # unixfs
-    test_expect_success "GET for /ipns/ unixfs dir listing succeeds" '
-    curl -svX GET "http://127.0.0.1:$GWAY_PORT/ipns/$TEST_IPNS_ID/root2/root3/" >/dev/null 2>curl_ipns_dir_listing_output
-    '
-    test_expect_success "GET for /ipns/ unixfs dir with index.html succeeds" '
-    curl -svX GET "http://127.0.0.1:$GWAY_PORT/ipns/$TEST_IPNS_ID/root2/root3/root4/" >/dev/null 2>curl_ipns_dir_index.html_output
-    '
-    test_expect_success "GET for /ipns/ unixfs file succeeds" '
-    curl -svX GET "http://127.0.0.1:$GWAY_PORT/ipns/$TEST_IPNS_ID/root2/root3/root4/index.html" >/dev/null 2>curl_ipns_file_output
-    '
-    # unixfs dir as dag-json
-    test_expect_success "GET for /ipns/ unixfs dir as DAG-JSON succeeds" '
-    curl -svX GET "http://127.0.0.1:$GWAY_PORT/ipns/$TEST_IPNS_ID/root2/root3/root4/?format=dag-json" >/dev/null 2>curl_ipns_dir_dag-json_output &&
-    curl -svX GET "http://127.0.0.1:$GWAY_PORT/ipns/$TEST_IPNS_ID/root2/root3/root4/?format=json" >/dev/null 2>curl_ipns_dir_json_output
-    '
-# Cache-Control: mutable /ipns/ file
-    test_expect_success "GET /ipns/ unixfs file has no Cache-Control" '
-    test_should_not_contain "< Cache-Control" curl_ipns_file_output
-    '
-# Cache-Control: mutable /ipns/dir/ (generated listing)
-    test_expect_success "GET /ipns/ unixfs dir listing has no Cache-Control" '
-    test_should_not_contain "< Cache-Control" curl_ipns_dir_listing_output
-    '
-# Cache-Control: mutable /ipns/dir/ (index.html)
-    test_expect_success "GET /ipns/ unixfs dir with index.html has no Cache-Control" '
-    test_should_not_contain "< Cache-Control" curl_ipns_dir_index.html_output
-    '
-# Cache-Control: mutable /ipns/dir/ as dag-json
-    test_expect_success "GET /ipns/ unixfs dir as dag-json has no Cache-Control" '
-    test_should_not_contain "< Cache-Control" curl_ipns_dir_dag-json_output
-    '
-# Cache-Control: mutable /ipns/dir/ as json
-    test_expect_success "GET /ipns/ unixfs dir as json has no Cache-Control" '
-    test_should_not_contain "< Cache-Control" curl_ipns_dir_json_output
-    '
-# X-Ipfs-Path
-    ## dir generated listing
-    test_expect_success "GET /ipns/ dir listing response has original content path in X-Ipfs-Path" '
-    test_should_contain "< X-Ipfs-Path: /ipns/$TEST_IPNS_ID/root2/root3" curl_ipns_dir_listing_output
-    '
-
-    ## dir static index.html
-    test_expect_success "GET /ipns/ dir index.html response has original content path in X-Ipfs-Path" '
-    test_should_contain "< X-Ipfs-Path: /ipns/$TEST_IPNS_ID/root2/root3/root4/" curl_ipns_dir_index.html_output
-    '
-
-    # file
-    test_expect_success "GET /ipns/ file response has original content path in X-Ipfs-Path" '
-    test_should_contain "< X-Ipfs-Path: /ipns/$TEST_IPNS_ID/root2/root3/root4/index.html" curl_ipns_file_output
-    '
-# X-Ipfs-Roots
-
-    ## dir generated listing
-    test_expect_success "GET /ipns/ dir listing response has logical CID roots in X-Ipfs-Roots" '
-    test_should_contain "< X-Ipfs-Roots: ${ROOT1_CID},${ROOT2_CID},${ROOT3_CID}" curl_ipns_dir_listing_output
-    '
-
-    ## dir static index.html
-    test_expect_success "GET /ipns/ dir index.html response has logical CID roots in X-Ipfs-Roots" '
-    test_should_contain "< X-Ipfs-Roots: ${ROOT1_CID},${ROOT2_CID},${ROOT3_CID},${ROOT4_CID}" curl_ipns_dir_index.html_output
-    '
-
-    ## file
-    test_expect_success "GET /ipns/ file response has logical CID roots in X-Ipfs-Roots" '
-    test_should_contain "< X-Ipfs-Roots: ${ROOT1_CID},${ROOT2_CID},${ROOT3_CID},${ROOT4_CID},${FILE_CID}" curl_ipns_file_output
-    '
-# Etag
-
-    ## dir generated listing
-    test_expect_success "GET /ipns/ dir response has special Etag for generated dir listing" '
-    test_should_contain "< Etag: \"DirIndex" curl_ipns_dir_listing_output &&
-    grep -E "< Etag: \"DirIndex-.+_CID-${ROOT3_CID}\"" curl_ipns_dir_listing_output
-    '
-
-    ## dir static index.html should use CID of  the index.html file for improved HTTP caching
-    test_expect_success "GET /ipns/ dir index.html response has dir CID as Etag" '
-    test_should_contain "< Etag: \"${ROOT4_CID}\"" curl_ipns_dir_index.html_output
-    '
-
-    ## file
-    test_expect_success "GET /ipns/ response has CID as Etag for a file" '
-    test_should_contain "< Etag: \"${FILE_CID}\"" curl_ipns_file_output
-    '
-
-		test_expect_success "GET for /ipns/ file with matching Etag in If-None-Match returns 304 Not Modified" '
-    curl -svX GET -H "If-None-Match: \"$FILE_CID\"" "http://127.0.0.1:$GWAY_PORT/ipns/$TEST_IPNS_ID/root2/root3/root4/index.html" >/dev/null 2>curl_output &&
-    test_should_contain "304 Not Modified" curl_output
-    '
-
-		# DirIndex etag is based on xxhash(./assets/dir-index-html), so we need to fetch it dynamically
-    test_expect_success "GET for /ipfs/ dir listing with matching strong Etag in If-None-Match returns 304 Not Modified" '
-    curl -Is "http://127.0.0.1:$GWAY_PORT/ipfs/$ROOT1_CID/root2/root3/"| grep -i Etag | cut -f2- -d: | tr -d "[:space:]\"" > dir_index_etag &&
-    curl -svX GET -H "If-None-Match: \"$(<dir_index_etag)\"" "http://127.0.0.1:$GWAY_PORT/ipfs/$ROOT1_CID/root2/root3/" >/dev/null 2>curl_output &&
-    test_should_contain "304 Not Modified" curl_output
-    '
-    test_expect_success "GET for /ipfs/ dir listing with matching weak Etag in If-None-Match returns 304 Not Modified" '
-    curl -Is "http://127.0.0.1:$GWAY_PORT/ipfs/$ROOT1_CID/root2/root3/"| grep -i Etag | cut -f2- -d: | tr -d "[:space:]\"" > dir_index_etag &&
-    curl -svX GET -H "If-None-Match: W/\"$(<dir_index_etag)\"" "http://127.0.0.1:$GWAY_PORT/ipfs/$ROOT1_CID/root2/root3/" >/dev/null 2>curl_output &&
-    test_should_contain "304 Not Modified" curl_output
-    '
+1.
+test_expect_success "GET for /ipns/ unixfs dir listing succeeds" '
+curl -svX GET "http://127.0.0.1:$GWAY_PORT/ipns/$TEST_IPNS_ID/root2/root3/" >/dev/null 2>curl_ipns_dir_listing_output
+'
+test_expect_success "GET /ipns/ unixfs dir listing has no Cache-Control" '
+test_should_not_contain "< Cache-Control" curl_ipns_dir_listing_output
+'
+test_expect_success "GET /ipns/ unixfs dir listing has no Cache-Control" '
+test_should_not_contain "< Cache-Control" curl_ipns_dir_listing_output
+'
+test_expect_success "GET /ipns/ dir listing response has original content path in X-Ipfs-Path" '
+test_should_contain "< X-Ipfs-Path: /ipns/$TEST_IPNS_ID/root2/root3" curl_ipns_dir_listing_output
+'
+test_expect_success "GET /ipns/ dir listing response has logical CID roots in X-Ipfs-Roots" '
+test_should_contain "< X-Ipfs-Roots: ${ROOT1_CID},${ROOT2_CID},${ROOT3_CID}" curl_ipns_dir_listing_output
+'
+test_expect_success "GET /ipns/ dir response has special Etag for generated dir listing" '
+test_should_contain "< Etag: \"DirIndex" curl_ipns_dir_listing_output &&
+grep -E "< Etag: \"DirIndex-.+_CID-${ROOT3_CID}\"" curl_ipns_dir_listing_output
+'
+2.
+test_expect_success "GET for /ipns/ unixfs dir with index.html succeeds" '
+curl -svX GET "http://127.0.0.1:$GWAY_PORT/ipns/$TEST_IPNS_ID/root2/root3/root4/" >/dev/null 2>curl_ipns_dir_index.html_output
+'
+test_expect_success "GET /ipns/ unixfs dir with index.html has no Cache-Control" '
+test_should_not_contain "< Cache-Control" curl_ipns_dir_index.html_output
+'
+test_expect_success "GET /ipns/ dir index.html response has original content path in X-Ipfs-Path" '
+test_should_contain "< X-Ipfs-Path: /ipns/$TEST_IPNS_ID/root2/root3/root4/" curl_ipns_dir_index.html_output
+'
+test_expect_success "GET /ipns/ dir index.html response has logical CID roots in X-Ipfs-Roots" '
+test_should_contain "< X-Ipfs-Roots: ${ROOT1_CID},${ROOT2_CID},${ROOT3_CID},${ROOT4_CID}" curl_ipns_dir_index.html_output
+'
+test_expect_success "GET /ipns/ dir index.html response has dir CID as Etag" '
+test_should_contain "< Etag: \"${ROOT4_CID}\"" curl_ipns_dir_index.html_output
+'
+3.
+test_expect_success "GET for /ipns/ unixfs file succeeds" '
+curl -svX GET "http://127.0.0.1:$GWAY_PORT/ipns/$TEST_IPNS_ID/root2/root3/root4/index.html" >/dev/null 2>curl_ipns_file_output
+'
+test_expect_success "GET /ipns/ unixfs file has no Cache-Control" '
+test_should_not_contain "< Cache-Control" curl_ipns_file_output
+'
+test_expect_success "GET /ipns/ file response has original content path in X-Ipfs-Path" '
+test_should_contain "< X-Ipfs-Path: /ipns/$TEST_IPNS_ID/root2/root3/root4/index.html" curl_ipns_file_output
+'
+test_expect_success "GET /ipns/ file response has logical CID roots in X-Ipfs-Roots" '
+test_should_contain "< X-Ipfs-Roots: ${ROOT1_CID},${ROOT2_CID},${ROOT3_CID},${ROOT4_CID},${FILE_CID}" curl_ipns_file_output
+'
+test_expect_success "GET /ipns/ response has CID as Etag for a file" '
+test_should_contain "< Etag: \"${FILE_CID}\"" curl_ipns_file_output
+'
+4.
+test_expect_success "GET for /ipns/ unixfs dir as DAG-JSON succeeds" '
+curl -svX GET "http://127.0.0.1:$GWAY_PORT/ipns/$TEST_IPNS_ID/root2/root3/root4/?format=dag-json" >/dev/null 2>curl_ipns_dir_dag-json_output
+'
+test_expect_success "GET /ipns/ unixfs dir as dag-json has no Cache-Control" '
+test_should_not_contain "< Cache-Control" curl_ipns_dir_dag-json_output
+'
+5.
+test_expect_success "GET for /ipns/ unixfs dir as DAG-JSON succeeds" '
+curl -svX GET "http://127.0.0.1:$GWAY_PORT/ipns/$TEST_IPNS_ID/root2/root3/root4/?format=json" >/dev/null 2>curl_ipns_dir_json_output
+'
+test_expect_success "GET /ipns/ unixfs dir as json has no Cache-Control" '
+test_should_not_contain "< Cache-Control" curl_ipns_dir_json_output
+'
+6.
+test_expect_success "GET for /ipns/ file with matching Etag in If-None-Match returns 304 Not Modified" '
+curl -svX GET -H "If-None-Match: \"$FILE_CID\"" "http://127.0.0.1:$GWAY_PORT/ipns/$TEST_IPNS_ID/root2/root3/root4/index.html" >/dev/null 2>curl_output &&
+test_should_contain "304 Not Modified" curl_output
+'
+7.
+# DirIndex etag is based on xxhash(./assets/dir-index-html), so we need to fetch it dynamically
+test_expect_success "GET for /ipfs/ dir listing with matching strong Etag in If-None-Match returns 304 Not Modified" '
+curl -Is "http://127.0.0.1:$GWAY_PORT/ipfs/$ROOT1_CID/root2/root3/"| grep -i Etag | cut -f2- -d: | tr -d "[:space:]\"" > dir_index_etag &&
+curl -svX GET -H "If-None-Match: \"$(<dir_index_etag)\"" "http://127.0.0.1:$GWAY_PORT/ipfs/$ROOT1_CID/root2/root3/" >/dev/null 2>curl_output &&
+test_should_contain "304 Not Modified" curl_output
+'
+8.
+test_expect_success "GET for /ipfs/ dir listing with matching weak Etag in If-None-Match returns 304 Not Modified" '
+curl -Is "http://127.0.0.1:$GWAY_PORT/ipfs/$ROOT1_CID/root2/root3/"| grep -i Etag | cut -f2- -d: | tr -d "[:space:]\"" > dir_index_etag &&
+curl -svX GET -H "If-None-Match: W/\"$(<dir_index_etag)\"" "http://127.0.0.1:$GWAY_PORT/ipfs/$ROOT1_CID/root2/root3/" >/dev/null 2>curl_output &&
+test_should_contain "304 Not Modified" curl_output
+'
 */
 func TestGatewayCache(t *testing.T) {
 	fixture := car.MustOpenUnixfsCar("t0116-gateway-cache.car")

--- a/tests/t0116_gateway_cache_test.go
+++ b/tests/t0116_gateway_cache_test.go
@@ -15,24 +15,6 @@ func TestGatewayCache(t *testing.T) {
 	var etag string
 
 	tests := SugarTests{
-		/*
-					test_expect_success "GET for /ipfs/ unixfs dir listing succeeds" '
-			    curl -svX GET "http://127.0.0.1:$GWAY_PORT/ipfs/$ROOT1_CID/root2/root3/" >/dev/null 2>curl_ipfs_dir_listing_output
-			    '
-					test_expect_success "GET /ipfs/ unixfs dir listing has no Cache-Control" '
-			    test_should_not_contain "< Cache-Control" curl_ipfs_dir_listing_output
-			    '
-					test_expect_success "GET /ipfs/ dir listing response has original content path in X-Ipfs-Path" '
-			    test_should_contain "< X-Ipfs-Path: /ipfs/$ROOT1_CID/root2/root3" curl_ipfs_dir_listing_output
-			    '
-					test_expect_success "GET /ipfs/ dir listing response has logical CID roots in X-Ipfs-Roots" '
-			    test_should_contain "< X-Ipfs-Roots: ${ROOT1_CID},${ROOT2_CID},${ROOT3_CID}" curl_ipfs_dir_listing_output
-			    '
-					test_expect_success "GET /ipfs/ dir response has special Etag for generated dir listing" '
-			    test_should_contain "< Etag: \"DirIndex" curl_ipfs_dir_listing_output &&
-			    grep -E "< Etag: \"DirIndex-.+_CID-${ROOT3_CID}\"" curl_ipfs_dir_listing_output
-			    '
-		*/
 		{
 			Name: "GET for /ipfs/ unixfs dir listing succeeds",
 			Request: Request().
@@ -50,23 +32,6 @@ func TestGatewayCache(t *testing.T) {
 						Matches("DirIndex-.*_CID-%s", fixture.MustGetCid("root2", "root3")),
 				),
 		},
-		/*
-					test_expect_success "GET for /ipfs/ unixfs dir with index.html succeeds" '
-			    curl -svX GET "http://127.0.0.1:$GWAY_PORT/ipfs/$ROOT1_CID/root2/root3/root4/" >/dev/null 2>curl_ipfs_dir_index.html_output
-			    '
-			    test_expect_success "GET /ipfs/ unixfs dir with index.html has expected Cache-Control" '
-			    test_should_contain "< Cache-Control: public, max-age=29030400, immutable" curl_ipfs_dir_index.html_output
-			    '
-					test_expect_success "GET /ipfs/ dir index.html response has original content path in X-Ipfs-Path" '
-			    test_should_contain "< X-Ipfs-Path: /ipfs/$ROOT1_CID/root2/root3/root4/" curl_ipfs_dir_index.html_output
-			    '
-					test_expect_success "GET /ipfs/ dir index.html response has logical CID roots in X-Ipfs-Roots" '
-			    test_should_contain "< X-Ipfs-Roots: ${ROOT1_CID},${ROOT2_CID},${ROOT3_CID},${ROOT4_CID}" curl_ipfs_dir_index.html_output
-			    '
-					test_expect_success "GET /ipfs/ dir index.html response has dir CID as Etag" '
-			    test_should_contain "< Etag: \"${ROOT4_CID}\"" curl_ipfs_dir_index.html_output
-			    '
-		*/
 		{
 			Name: "GET for /ipfs/ unixfs dir with index.html succeeds",
 			Request: Request().
@@ -84,23 +49,6 @@ func TestGatewayCache(t *testing.T) {
 						Equals("\"%s\"", fixture.MustGetCid("root2", "root3", "root4")),
 				),
 		},
-		/*
-					test_expect_success "GET for /ipfs/ unixfs file succeeds" '
-			    curl -svX GET "http://127.0.0.1:$GWAY_PORT/ipfs/$ROOT1_CID/root2/root3/root4/index.html" >/dev/null 2>curl_ipfs_file_output
-			    '
-					test_expect_success "GET /ipfs/ unixfs file has expected Cache-Control" '
-			    test_should_contain "< Cache-Control: public, max-age=29030400, immutable" curl_ipfs_file_output
-			    '
-					test_expect_success "GET /ipfs/ file response has original content path in X-Ipfs-Path" '
-			    test_should_contain "< X-Ipfs-Path: /ipfs/$ROOT1_CID/root2/root3/root4/index.html" curl_ipfs_file_output
-			    '
-					test_expect_success "GET /ipfs/ file response has logical CID roots in X-Ipfs-Roots" '
-			    test_should_contain "< X-Ipfs-Roots: ${ROOT1_CID},${ROOT2_CID},${ROOT3_CID},${ROOT4_CID},${FILE_CID}" curl_ipfs_file_output
-			    '
-					test_expect_success "GET /ipfs/ response has CID as Etag for a file" '
-			    test_should_contain "< Etag: \"${FILE_CID}\"" curl_ipfs_file_output
-			    '
-		*/
 		{
 			Name: "GET for /ipfs/ unixfs file succeeds",
 			Request: Request().
@@ -118,14 +66,6 @@ func TestGatewayCache(t *testing.T) {
 						Equals("\"%s\"", fixture.MustGetCid("root2", "root3", "root4", "index.html")),
 				),
 		},
-		/*
-					test_expect_success "GET for /ipfs/ unixfs dir as DAG-JSON succeeds" '
-			    curl -svX GET "http://127.0.0.1:$GWAY_PORT/ipfs/$ROOT1_CID/root2/root3/root4/?format=dag-json" >/dev/null 2>curl_ipfs_dir_dag-json_output
-			    '
-			    test_expect_success "GET /ipfs/ dag-json has expected Cache-Control" '
-			    test_should_contain "< Cache-Control: public, max-age=29030400, immutable" curl_ipfs_dir_dag-json_output
-			    '
-		*/
 		{
 			Name: "GET for /ipfs/ unixfs dir as DAG-JSON succeeds",
 			Request: Request().
@@ -138,14 +78,6 @@ func TestGatewayCache(t *testing.T) {
 						Equals("public, max-age=29030400, immutable"),
 				),
 		},
-		/*
-					test_expect_success "GET for /ipfs/ unixfs dir as DAG-JSON succeeds" '
-			    curl -svX GET "http://127.0.0.1:$GWAY_PORT/ipfs/$ROOT1_CID/root2/root3/root4/?format=json" >/dev/null 2>curl_ipfs_dir_json_output
-			    '
-			    test_expect_success "GET /ipfs/ unixfs dir as json has expected Cache-Control" '
-			    test_should_contain "< Cache-Control: public, max-age=29030400, immutable" curl_ipfs_dir_json_output
-			    '
-		*/
 		{
 			Name: "GET for /ipfs/ unixfs dir as JSON succeeds",
 			Request: Request().
@@ -158,13 +90,6 @@ func TestGatewayCache(t *testing.T) {
 						Equals("public, max-age=29030400, immutable"),
 				),
 		},
-		/*
-					test_expect_success "HEAD for /ipfs/ with only-if-cached succeeds when in local datastore" '
-			    curl -sv -I -H "Cache-Control: only-if-cached" "http://127.0.0.1:$GWAY_PORT/ipfs/$ROOT1_CID/root2/root3/root4/index.html" > curl_onlyifcached_postitive_head 2>&1 &&
-			    cat curl_onlyifcached_postitive_head &&
-			    grep "< HTTP/1.1 200 OK" curl_onlyifcached_postitive_head
-			    '
-		*/
 		{
 			Name: "HEAD for /ipfs/ with only-if-cached succeeds when in local datastore",
 			Request: Request().
@@ -176,13 +101,6 @@ func TestGatewayCache(t *testing.T) {
 			Response: Expect().
 				Status(200),
 		},
-		/*
-					test_expect_success "HEAD for /ipfs/ with only-if-cached fails when not in local datastore" '
-			    curl -sv -I -H "Cache-Control: only-if-cached" "http://127.0.0.1:$GWAY_PORT/ipfs/$(date | ipfs add --only-hash -Q)" > curl_onlyifcached_negative_head 2>&1 &&
-			    cat curl_onlyifcached_negative_head &&
-			    grep "< HTTP/1.1 412 Precondition Failed" curl_onlyifcached_negative_head
-			    '
-		*/
 		{
 			Name: "HEAD for /ipfs/ with only-if-cached fails when not in local datastore",
 			Request: Request().
@@ -194,13 +112,6 @@ func TestGatewayCache(t *testing.T) {
 			Response: Expect().
 				Status(412),
 		},
-		/*
-					test_expect_success "GET for /ipfs/ with only-if-cached succeeds when in local datastore" '
-			    curl -svX GET -H "Cache-Control: only-if-cached" "http://127.0.0.1:$GWAY_PORT/ipfs/$ROOT1_CID/root2/root3/root4/index.html" >/dev/null 2>curl_onlyifcached_postitive_out &&
-			    cat curl_onlyifcached_postitive_out &&
-			    grep "< HTTP/1.1 200 OK" curl_onlyifcached_postitive_out
-			    '
-		*/
 		{
 			Name: "GET for /ipfs/ with only-if-cached succeeds when in local datastore",
 			Request: Request().
@@ -211,13 +122,6 @@ func TestGatewayCache(t *testing.T) {
 			Response: Expect().
 				Status(200),
 		},
-		/*
-					test_expect_success "GET for /ipfs/ with only-if-cached fails when not in local datastore" '
-			    curl -svX GET -H "Cache-Control: only-if-cached" "http://127.0.0.1:$GWAY_PORT/ipfs/$(date | ipfs add --only-hash -Q)" >/dev/null 2>curl_onlyifcached_negative_out &&
-			    cat curl_onlyifcached_negative_out &&
-			    grep "< HTTP/1.1 412 Precondition Failed" curl_onlyifcached_negative_out
-			    '
-		*/
 		{
 			Name: "GET for /ipfs/ with only-if-cached fails when not in local datastore",
 			Request: Request().
@@ -228,12 +132,6 @@ func TestGatewayCache(t *testing.T) {
 			Response: Expect().
 				Status(412),
 		},
-		/*
-					test_expect_success "GET for /ipfs/ file with matching Etag in If-None-Match returns 304 Not Modified" '
-			    curl -svX GET -H "If-None-Match: \"$FILE_CID\"" "http://127.0.0.1:$GWAY_PORT/ipfs/$ROOT1_CID/root2/root3/root4/index.html" >/dev/null 2>curl_output &&
-			    test_should_contain "304 Not Modified" curl_output
-			    '
-		*/
 		{
 			Name: "GET for /ipfs/ file with matching Etag in If-None-Match returns 304 Not Modified",
 			Request: Request().
@@ -244,12 +142,6 @@ func TestGatewayCache(t *testing.T) {
 			Response: Expect().
 				Status(304),
 		},
-		/*
-					test_expect_success "GET for /ipfs/ dir with index.html file with matching Etag in If-None-Match returns 304 Not Modified" '
-			    curl -svX GET -H "If-None-Match: \"$ROOT4_CID\"" "http://127.0.0.1:$GWAY_PORT/ipfs/$ROOT1_CID/root2/root3/root4/" >/dev/null 2>curl_output &&
-			    test_should_contain "304 Not Modified" curl_output
-			    '
-		*/
 		{
 			Name: "GET for /ipfs/ dir with index.html file with matching Etag in If-None-Match returns 304 Not Modified",
 			Request: Request().
@@ -260,12 +152,6 @@ func TestGatewayCache(t *testing.T) {
 			Response: Expect().
 				Status(304),
 		},
-		/*
-					test_expect_success "GET for /ipfs/ file with matching third Etag in If-None-Match returns 304 Not Modified" '
-			    curl -svX GET -H "If-None-Match: \"fakeEtag1\", \"fakeEtag2\", \"$FILE_CID\"" "http://127.0.0.1:$GWAY_PORT/ipfs/$ROOT1_CID/root2/root3/root4/index.html" >/dev/null 2>curl_output &&
-			    test_should_contain "304 Not Modified" curl_output
-			    '
-		*/
 		{
 			Name: "GET for /ipfs/ file with matching third Etag in If-None-Match returns 304 Not Modified",
 			Request: Request().
@@ -276,12 +162,6 @@ func TestGatewayCache(t *testing.T) {
 			Response: Expect().
 				Status(304),
 		},
-		/*
-					test_expect_success "GET for /ipfs/ file with matching weak Etag in If-None-Match returns 304 Not Modified" '
-			    curl -svX GET -H "If-None-Match: W/\"$FILE_CID\"" "http://127.0.0.1:$GWAY_PORT/ipfs/$ROOT1_CID/root2/root3/root4/index.html" >/dev/null 2>curl_output &&
-			    test_should_contain "304 Not Modified" curl_output
-			    '
-		*/
 		{
 			Name: "GET for /ipfs/ file with matching weak Etag in If-None-Match returns 304 Not Modified",
 			Request: Request().
@@ -292,12 +172,6 @@ func TestGatewayCache(t *testing.T) {
 			Response: Expect().
 				Status(304),
 		},
-		/*
-					test_expect_success "GET for /ipfs/ file with wildcard Etag in If-None-Match returns 304 Not Modified" '
-			    curl -svX GET -H "If-None-Match: *" "http://127.0.0.1:$GWAY_PORT/ipfs/$ROOT1_CID/root2/root3/root4/index.html" >/dev/null 2>curl_output &&
-			    test_should_contain "304 Not Modified" curl_output
-			    '
-		*/
 		{
 			Name: "GET for /ipfs/ file with wildcard Etag in If-None-Match returns 304 Not Modified",
 			Request: Request().
@@ -308,12 +182,6 @@ func TestGatewayCache(t *testing.T) {
 			Response: Expect().
 				Status(304),
 		},
-		/*
-					test_expect_success "GET for /ipfs/ dir listing with matching weak Etag in If-None-Match returns 304 Not Modified" '
-			    curl -svX GET -H "If-None-Match: W/\"$ROOT3_CID\"" "http://127.0.0.1:$GWAY_PORT/ipfs/$ROOT1_CID/root2/root3/" >/dev/null 2>curl_output &&
-			    test_should_contain "304 Not Modified" curl_output
-			    '
-		*/
 		{
 			Name: "GET for /ipfs/ dir listing with matching weak Etag in If-None-Match returns 304 Not Modified",
 			Request: Request().
@@ -324,27 +192,6 @@ func TestGatewayCache(t *testing.T) {
 			Response: Expect().
 				Status(304),
 		},
-		/*
-			test_expect_success "GET for /ipns/ unixfs dir listing succeeds" '
-			curl -svX GET "http://127.0.0.1:$GWAY_PORT/ipns/$TEST_IPNS_ID/root2/root3/" >/dev/null 2>curl_ipns_dir_listing_output
-			'
-			test_expect_success "GET /ipns/ unixfs dir listing has no Cache-Control" '
-			test_should_not_contain "< Cache-Control" curl_ipns_dir_listing_output
-			'
-			test_expect_success "GET /ipns/ unixfs dir listing has no Cache-Control" '
-			test_should_not_contain "< Cache-Control" curl_ipns_dir_listing_output
-			'
-			test_expect_success "GET /ipns/ dir listing response has original content path in X-Ipfs-Path" '
-			test_should_contain "< X-Ipfs-Path: /ipns/$TEST_IPNS_ID/root2/root3" curl_ipns_dir_listing_output
-			'
-			test_expect_success "GET /ipns/ dir listing response has logical CID roots in X-Ipfs-Roots" '
-			test_should_contain "< X-Ipfs-Roots: ${ROOT1_CID},${ROOT2_CID},${ROOT3_CID}" curl_ipns_dir_listing_output
-			'
-			test_expect_success "GET /ipns/ dir response has special Etag for generated dir listing" '
-			test_should_contain "< Etag: \"DirIndex" curl_ipns_dir_listing_output &&
-			grep -E "< Etag: \"DirIndex-.+_CID-${ROOT3_CID}\"" curl_ipns_dir_listing_output
-			'
-		*/
 		{
 			Name: "GET for /ipns/ unixfs dir listing succeeds",
 			Request: Request().
@@ -362,23 +209,6 @@ func TestGatewayCache(t *testing.T) {
 						Matches("DirIndex-.*_CID-%s", fixture.MustGetCid("root2", "root3")),
 				),
 		},
-		/*
-			test_expect_success "GET for /ipns/ unixfs dir with index.html succeeds" '
-			curl -svX GET "http://127.0.0.1:$GWAY_PORT/ipns/$TEST_IPNS_ID/root2/root3/root4/" >/dev/null 2>curl_ipns_dir_index.html_output
-			'
-			test_expect_success "GET /ipns/ unixfs dir with index.html has no Cache-Control" '
-			test_should_not_contain "< Cache-Control" curl_ipns_dir_index.html_output
-			'
-			test_expect_success "GET /ipns/ dir index.html response has original content path in X-Ipfs-Path" '
-			test_should_contain "< X-Ipfs-Path: /ipns/$TEST_IPNS_ID/root2/root3/root4/" curl_ipns_dir_index.html_output
-			'
-			test_expect_success "GET /ipns/ dir index.html response has logical CID roots in X-Ipfs-Roots" '
-			test_should_contain "< X-Ipfs-Roots: ${ROOT1_CID},${ROOT2_CID},${ROOT3_CID},${ROOT4_CID}" curl_ipns_dir_index.html_output
-			'
-			test_expect_success "GET /ipns/ dir index.html response has dir CID as Etag" '
-			test_should_contain "< Etag: \"${ROOT4_CID}\"" curl_ipns_dir_index.html_output
-			'
-		*/
 		{
 			Name: "GET for /ipns/ unixfs dir with index.html succeeds",
 			Request: Request().
@@ -396,23 +226,6 @@ func TestGatewayCache(t *testing.T) {
 						Matches("DirIndex-.*_CID-%s", fixture.MustGetCid("root2", "root3", "root4")),
 				),
 		},
-		/*
-			test_expect_success "GET for /ipns/ unixfs file succeeds" '
-			curl -svX GET "http://127.0.0.1:$GWAY_PORT/ipns/$TEST_IPNS_ID/root2/root3/root4/index.html" >/dev/null 2>curl_ipns_file_output
-			'
-			test_expect_success "GET /ipns/ unixfs file has no Cache-Control" '
-			test_should_not_contain "< Cache-Control" curl_ipns_file_output
-			'
-			test_expect_success "GET /ipns/ file response has original content path in X-Ipfs-Path" '
-			test_should_contain "< X-Ipfs-Path: /ipns/$TEST_IPNS_ID/root2/root3/root4/index.html" curl_ipns_file_output
-			'
-			test_expect_success "GET /ipns/ file response has logical CID roots in X-Ipfs-Roots" '
-			test_should_contain "< X-Ipfs-Roots: ${ROOT1_CID},${ROOT2_CID},${ROOT3_CID},${ROOT4_CID},${FILE_CID}" curl_ipns_file_output
-			'
-			test_expect_success "GET /ipns/ response has CID as Etag for a file" '
-			test_should_contain "< Etag: \"${FILE_CID}\"" curl_ipns_file_output
-			'
-		*/
 		{
 			Name: "GET for /ipns/ unixfs file succeeds",
 			Request: Request().
@@ -430,14 +243,6 @@ func TestGatewayCache(t *testing.T) {
 						Equals("\"%s\"", fixture.MustGetCid("root2", "root3", "root4", "index.html")),
 				),
 		},
-		/*
-			test_expect_success "GET for /ipns/ unixfs dir as DAG-JSON succeeds" '
-			curl -svX GET "http://127.0.0.1:$GWAY_PORT/ipns/$TEST_IPNS_ID/root2/root3/root4/?format=dag-json" >/dev/null 2>curl_ipns_dir_dag-json_output
-			'
-			test_expect_success "GET /ipns/ unixfs dir as dag-json has no Cache-Control" '
-			test_should_not_contain "< Cache-Control" curl_ipns_dir_dag-json_output
-			'
-		*/
 		{
 			Name: "GET for /ipns/ unixfs dir as DAG-JSON succeeds",
 			Request: Request().
@@ -450,14 +255,6 @@ func TestGatewayCache(t *testing.T) {
 						Equals("public, max-age=29030400, immutable"),
 				),
 		},
-		/*
-			test_expect_success "GET for /ipns/ unixfs dir as DAG-JSON succeeds" '
-			curl -svX GET "http://127.0.0.1:$GWAY_PORT/ipns/$TEST_IPNS_ID/root2/root3/root4/?format=json" >/dev/null 2>curl_ipns_dir_json_output
-			'
-			test_expect_success "GET /ipns/ unixfs dir as json has no Cache-Control" '
-			test_should_not_contain "< Cache-Control" curl_ipns_dir_json_output
-			'
-		*/
 		{
 			Name: "GET for /ipns/ unixfs dir as JSON succeeds",
 			Request: Request().
@@ -470,12 +267,6 @@ func TestGatewayCache(t *testing.T) {
 						Equals("public, max-age=29030400, immutable"),
 				),
 		},
-		/*
-			test_expect_success "GET for /ipns/ file with matching Etag in If-None-Match returns 304 Not Modified" '
-			curl -svX GET -H "If-None-Match: \"$FILE_CID\"" "http://127.0.0.1:$GWAY_PORT/ipns/$TEST_IPNS_ID/root2/root3/root4/index.html" >/dev/null 2>curl_output &&
-			test_should_contain "304 Not Modified" curl_output
-			'
-		*/
 		{
 			Name: "GET for /ipns/ file with matching Etag in If-None-Match returns 304 Not Modified",
 			Request: Request().
@@ -486,14 +277,6 @@ func TestGatewayCache(t *testing.T) {
 			Response: Expect().
 				Status(304),
 		},
-		/*
-			# DirIndex etag is based on xxhash(./assets/dir-index-html), so we need to fetch it dynamically
-			test_expect_success "GET for /ipfs/ dir listing with matching strong Etag in If-None-Match returns 304 Not Modified" '
-			curl -Is "http://127.0.0.1:$GWAY_PORT/ipfs/$ROOT1_CID/root2/root3/"| grep -i Etag | cut -f2- -d: | tr -d "[:space:]\"" > dir_index_etag &&
-			curl -svX GET -H "If-None-Match: \"$(<dir_index_etag)\"" "http://127.0.0.1:$GWAY_PORT/ipfs/$ROOT1_CID/root2/root3/" >/dev/null 2>curl_output &&
-			test_should_contain "304 Not Modified" curl_output
-			'
-		*/
 		{
 			Name: "GET for /ipfs/ dir listing with matching strong Etag in If-None-Match returns 304 Not Modified",
 			Request: Request().
@@ -504,13 +287,6 @@ func TestGatewayCache(t *testing.T) {
 			Response: Expect().
 				Status(304),
 		},
-		/*
-			test_expect_success "GET for /ipfs/ dir listing with matching weak Etag in If-None-Match returns 304 Not Modified" '
-			curl -Is "http://127.0.0.1:$GWAY_PORT/ipfs/$ROOT1_CID/root2/root3/"| grep -i Etag | cut -f2- -d: | tr -d "[:space:]\"" > dir_index_etag &&
-			curl -svX GET -H "If-None-Match: W/\"$(<dir_index_etag)\"" "http://127.0.0.1:$GWAY_PORT/ipfs/$ROOT1_CID/root2/root3/" >/dev/null 2>curl_output &&
-			test_should_contain "304 Not Modified" curl_output
-			'
-		*/
 		{
 			Name: "GET for /ipfs/ dir listing with matching strong Etag in If-None-Match returns 304 Not Modified",
 			Request: Request().

--- a/tests/t0116_gateway_cache_test.go
+++ b/tests/t0116_gateway_cache_test.go
@@ -8,14 +8,131 @@ import (
 	. "github.com/ipfs/gateway-conformance/tooling/test"
 )
 
-/* These tests do not cover the following:
-** - /ipns/ paths
-** - "If-None-Match" header handling for strong ETags for dir listings (the ones with xxhash)
- */
+/* TODO
+# GET /ipns/
+    # unixfs
+    test_expect_success "GET for /ipns/ unixfs dir listing succeeds" '
+    curl -svX GET "http://127.0.0.1:$GWAY_PORT/ipns/$TEST_IPNS_ID/root2/root3/" >/dev/null 2>curl_ipns_dir_listing_output
+    '
+    test_expect_success "GET for /ipns/ unixfs dir with index.html succeeds" '
+    curl -svX GET "http://127.0.0.1:$GWAY_PORT/ipns/$TEST_IPNS_ID/root2/root3/root4/" >/dev/null 2>curl_ipns_dir_index.html_output
+    '
+    test_expect_success "GET for /ipns/ unixfs file succeeds" '
+    curl -svX GET "http://127.0.0.1:$GWAY_PORT/ipns/$TEST_IPNS_ID/root2/root3/root4/index.html" >/dev/null 2>curl_ipns_file_output
+    '
+    # unixfs dir as dag-json
+    test_expect_success "GET for /ipns/ unixfs dir as DAG-JSON succeeds" '
+    curl -svX GET "http://127.0.0.1:$GWAY_PORT/ipns/$TEST_IPNS_ID/root2/root3/root4/?format=dag-json" >/dev/null 2>curl_ipns_dir_dag-json_output &&
+    curl -svX GET "http://127.0.0.1:$GWAY_PORT/ipns/$TEST_IPNS_ID/root2/root3/root4/?format=json" >/dev/null 2>curl_ipns_dir_json_output
+    '
+# Cache-Control: mutable /ipns/ file
+    test_expect_success "GET /ipns/ unixfs file has no Cache-Control" '
+    test_should_not_contain "< Cache-Control" curl_ipns_file_output
+    '
+# Cache-Control: mutable /ipns/dir/ (generated listing)
+    test_expect_success "GET /ipns/ unixfs dir listing has no Cache-Control" '
+    test_should_not_contain "< Cache-Control" curl_ipns_dir_listing_output
+    '
+# Cache-Control: mutable /ipns/dir/ (index.html)
+    test_expect_success "GET /ipns/ unixfs dir with index.html has no Cache-Control" '
+    test_should_not_contain "< Cache-Control" curl_ipns_dir_index.html_output
+    '
+# Cache-Control: mutable /ipns/dir/ as dag-json
+    test_expect_success "GET /ipns/ unixfs dir as dag-json has no Cache-Control" '
+    test_should_not_contain "< Cache-Control" curl_ipns_dir_dag-json_output
+    '
+# Cache-Control: mutable /ipns/dir/ as json
+    test_expect_success "GET /ipns/ unixfs dir as json has no Cache-Control" '
+    test_should_not_contain "< Cache-Control" curl_ipns_dir_json_output
+    '
+# X-Ipfs-Path
+    ## dir generated listing
+    test_expect_success "GET /ipns/ dir listing response has original content path in X-Ipfs-Path" '
+    test_should_contain "< X-Ipfs-Path: /ipns/$TEST_IPNS_ID/root2/root3" curl_ipns_dir_listing_output
+    '
+
+    ## dir static index.html
+    test_expect_success "GET /ipns/ dir index.html response has original content path in X-Ipfs-Path" '
+    test_should_contain "< X-Ipfs-Path: /ipns/$TEST_IPNS_ID/root2/root3/root4/" curl_ipns_dir_index.html_output
+    '
+
+    # file
+    test_expect_success "GET /ipns/ file response has original content path in X-Ipfs-Path" '
+    test_should_contain "< X-Ipfs-Path: /ipns/$TEST_IPNS_ID/root2/root3/root4/index.html" curl_ipns_file_output
+    '
+# X-Ipfs-Roots
+
+    ## dir generated listing
+    test_expect_success "GET /ipns/ dir listing response has logical CID roots in X-Ipfs-Roots" '
+    test_should_contain "< X-Ipfs-Roots: ${ROOT1_CID},${ROOT2_CID},${ROOT3_CID}" curl_ipns_dir_listing_output
+    '
+
+    ## dir static index.html
+    test_expect_success "GET /ipns/ dir index.html response has logical CID roots in X-Ipfs-Roots" '
+    test_should_contain "< X-Ipfs-Roots: ${ROOT1_CID},${ROOT2_CID},${ROOT3_CID},${ROOT4_CID}" curl_ipns_dir_index.html_output
+    '
+
+    ## file
+    test_expect_success "GET /ipns/ file response has logical CID roots in X-Ipfs-Roots" '
+    test_should_contain "< X-Ipfs-Roots: ${ROOT1_CID},${ROOT2_CID},${ROOT3_CID},${ROOT4_CID},${FILE_CID}" curl_ipns_file_output
+    '
+# Etag
+
+    ## dir generated listing
+    test_expect_success "GET /ipns/ dir response has special Etag for generated dir listing" '
+    test_should_contain "< Etag: \"DirIndex" curl_ipns_dir_listing_output &&
+    grep -E "< Etag: \"DirIndex-.+_CID-${ROOT3_CID}\"" curl_ipns_dir_listing_output
+    '
+
+    ## dir static index.html should use CID of  the index.html file for improved HTTP caching
+    test_expect_success "GET /ipns/ dir index.html response has dir CID as Etag" '
+    test_should_contain "< Etag: \"${ROOT4_CID}\"" curl_ipns_dir_index.html_output
+    '
+
+    ## file
+    test_expect_success "GET /ipns/ response has CID as Etag for a file" '
+    test_should_contain "< Etag: \"${FILE_CID}\"" curl_ipns_file_output
+    '
+
+		test_expect_success "GET for /ipns/ file with matching Etag in If-None-Match returns 304 Not Modified" '
+    curl -svX GET -H "If-None-Match: \"$FILE_CID\"" "http://127.0.0.1:$GWAY_PORT/ipns/$TEST_IPNS_ID/root2/root3/root4/index.html" >/dev/null 2>curl_output &&
+    test_should_contain "304 Not Modified" curl_output
+    '
+
+		# DirIndex etag is based on xxhash(./assets/dir-index-html), so we need to fetch it dynamically
+    test_expect_success "GET for /ipfs/ dir listing with matching strong Etag in If-None-Match returns 304 Not Modified" '
+    curl -Is "http://127.0.0.1:$GWAY_PORT/ipfs/$ROOT1_CID/root2/root3/"| grep -i Etag | cut -f2- -d: | tr -d "[:space:]\"" > dir_index_etag &&
+    curl -svX GET -H "If-None-Match: \"$(<dir_index_etag)\"" "http://127.0.0.1:$GWAY_PORT/ipfs/$ROOT1_CID/root2/root3/" >/dev/null 2>curl_output &&
+    test_should_contain "304 Not Modified" curl_output
+    '
+    test_expect_success "GET for /ipfs/ dir listing with matching weak Etag in If-None-Match returns 304 Not Modified" '
+    curl -Is "http://127.0.0.1:$GWAY_PORT/ipfs/$ROOT1_CID/root2/root3/"| grep -i Etag | cut -f2- -d: | tr -d "[:space:]\"" > dir_index_etag &&
+    curl -svX GET -H "If-None-Match: W/\"$(<dir_index_etag)\"" "http://127.0.0.1:$GWAY_PORT/ipfs/$ROOT1_CID/root2/root3/" >/dev/null 2>curl_output &&
+    test_should_contain "304 Not Modified" curl_output
+    '
+*/
 func TestGatewayCache(t *testing.T) {
 	fixture := car.MustOpenUnixfsCar("t0116-gateway-cache.car")
 
 	tests := SugarTests{
+		/*
+		test_expect_success "GET for /ipfs/ unixfs dir listing succeeds" '
+    curl -svX GET "http://127.0.0.1:$GWAY_PORT/ipfs/$ROOT1_CID/root2/root3/" >/dev/null 2>curl_ipfs_dir_listing_output
+    '
+		test_expect_success "GET /ipfs/ unixfs dir listing has no Cache-Control" '
+    test_should_not_contain "< Cache-Control" curl_ipfs_dir_listing_output
+    '
+		test_expect_success "GET /ipfs/ dir listing response has original content path in X-Ipfs-Path" '
+    test_should_contain "< X-Ipfs-Path: /ipfs/$ROOT1_CID/root2/root3" curl_ipfs_dir_listing_output
+    '
+		test_expect_success "GET /ipfs/ dir listing response has logical CID roots in X-Ipfs-Roots" '
+    test_should_contain "< X-Ipfs-Roots: ${ROOT1_CID},${ROOT2_CID},${ROOT3_CID}" curl_ipfs_dir_listing_output
+    '
+		test_expect_success "GET /ipfs/ dir response has special Etag for generated dir listing" '
+    test_should_contain "< Etag: \"DirIndex" curl_ipfs_dir_listing_output &&
+    grep -E "< Etag: \"DirIndex-.+_CID-${ROOT3_CID}\"" curl_ipfs_dir_listing_output
+    '
+		*/
 		{
 			Name: "GET for /ipfs/ unixfs dir listing succeeds",
 			Request: Request().
@@ -33,6 +150,23 @@ func TestGatewayCache(t *testing.T) {
 						Matches("DirIndex-.*_CID-%s", fixture.MustGetCid("root2", "root3")),
 				),
 		},
+		/*
+		test_expect_success "GET for /ipfs/ unixfs dir with index.html succeeds" '
+    curl -svX GET "http://127.0.0.1:$GWAY_PORT/ipfs/$ROOT1_CID/root2/root3/root4/" >/dev/null 2>curl_ipfs_dir_index.html_output
+    '
+    test_expect_success "GET /ipfs/ unixfs dir with index.html has expected Cache-Control" '
+    test_should_contain "< Cache-Control: public, max-age=29030400, immutable" curl_ipfs_dir_index.html_output
+    '
+		test_expect_success "GET /ipfs/ dir index.html response has original content path in X-Ipfs-Path" '
+    test_should_contain "< X-Ipfs-Path: /ipfs/$ROOT1_CID/root2/root3/root4/" curl_ipfs_dir_index.html_output
+    '
+		test_expect_success "GET /ipfs/ dir index.html response has logical CID roots in X-Ipfs-Roots" '
+    test_should_contain "< X-Ipfs-Roots: ${ROOT1_CID},${ROOT2_CID},${ROOT3_CID},${ROOT4_CID}" curl_ipfs_dir_index.html_output
+    '
+		test_expect_success "GET /ipfs/ dir index.html response has dir CID as Etag" '
+    test_should_contain "< Etag: \"${ROOT4_CID}\"" curl_ipfs_dir_index.html_output
+    '
+		*/
 		{
 			Name: "GET for /ipfs/ unixfs dir with index.html succeeds",
 			Request: Request().
@@ -50,6 +184,23 @@ func TestGatewayCache(t *testing.T) {
 						Equals("\"%s\"", fixture.MustGetCid("root2", "root3", "root4")),
 				),
 		},
+		/*
+		test_expect_success "GET for /ipfs/ unixfs file succeeds" '
+    curl -svX GET "http://127.0.0.1:$GWAY_PORT/ipfs/$ROOT1_CID/root2/root3/root4/index.html" >/dev/null 2>curl_ipfs_file_output
+    '
+		test_expect_success "GET /ipfs/ unixfs file has expected Cache-Control" '
+    test_should_contain "< Cache-Control: public, max-age=29030400, immutable" curl_ipfs_file_output
+    '
+		test_expect_success "GET /ipfs/ file response has original content path in X-Ipfs-Path" '
+    test_should_contain "< X-Ipfs-Path: /ipfs/$ROOT1_CID/root2/root3/root4/index.html" curl_ipfs_file_output
+    '
+		test_expect_success "GET /ipfs/ file response has logical CID roots in X-Ipfs-Roots" '
+    test_should_contain "< X-Ipfs-Roots: ${ROOT1_CID},${ROOT2_CID},${ROOT3_CID},${ROOT4_CID},${FILE_CID}" curl_ipfs_file_output
+    '
+		test_expect_success "GET /ipfs/ response has CID as Etag for a file" '
+    test_should_contain "< Etag: \"${FILE_CID}\"" curl_ipfs_file_output
+    '
+		*/
 		{
 			Name: "GET for /ipfs/ unixfs file succeeds",
 			Request: Request().
@@ -67,10 +218,19 @@ func TestGatewayCache(t *testing.T) {
 						Equals("\"%s\"", fixture.MustGetCid("root2", "root3", "root4", "index.html")),
 				),
 		},
+		/*
+		test_expect_success "GET for /ipfs/ unixfs dir as DAG-JSON succeeds" '
+    curl -svX GET "http://127.0.0.1:$GWAY_PORT/ipfs/$ROOT1_CID/root2/root3/root4/?format=dag-json" >/dev/null 2>curl_ipfs_dir_dag-json_output
+    '
+    test_expect_success "GET /ipfs/ dag-json has expected Cache-Control" '
+    test_should_contain "< Cache-Control: public, max-age=29030400, immutable" curl_ipfs_dir_dag-json_output
+    '
+		*/
 		{
 			Name: "GET for /ipfs/ unixfs dir as DAG-JSON succeeds",
 			Request: Request().
-				Path("ipfs/%s/root2/root3/root4/?format=dag-json", fixture.MustGetCid()),
+				Path("ipfs/%s/root2/root3/root4/", fixture.MustGetCid()).
+				Query("format", "dag-json"),
 			Response: Expect().
 				Status(200).
 				Headers(
@@ -78,10 +238,19 @@ func TestGatewayCache(t *testing.T) {
 						Equals("public, max-age=29030400, immutable"),
 				),
 		},
+		/*
+		test_expect_success "GET for /ipfs/ unixfs dir as DAG-JSON succeeds" '
+    curl -svX GET "http://127.0.0.1:$GWAY_PORT/ipfs/$ROOT1_CID/root2/root3/root4/?format=json" >/dev/null 2>curl_ipfs_dir_json_output
+    '
+    test_expect_success "GET /ipfs/ unixfs dir as json has expected Cache-Control" '
+    test_should_contain "< Cache-Control: public, max-age=29030400, immutable" curl_ipfs_dir_json_output
+    '
+		*/
 		{
 			Name: "GET for /ipfs/ unixfs dir as JSON succeeds",
 			Request: Request().
-				Path("ipfs/%s/root2/root3/root4/?format=json", fixture.MustGetCid()),
+				Path("ipfs/%s/root2/root3/root4/", fixture.MustGetCid()).
+				Query("format", "json"),
 			Response: Expect().
 				Status(200).
 				Headers(
@@ -89,6 +258,13 @@ func TestGatewayCache(t *testing.T) {
 						Equals("public, max-age=29030400, immutable"),
 				),
 		},
+		/*
+		test_expect_success "HEAD for /ipfs/ with only-if-cached succeeds when in local datastore" '
+    curl -sv -I -H "Cache-Control: only-if-cached" "http://127.0.0.1:$GWAY_PORT/ipfs/$ROOT1_CID/root2/root3/root4/index.html" > curl_onlyifcached_postitive_head 2>&1 &&
+    cat curl_onlyifcached_postitive_head &&
+    grep "< HTTP/1.1 200 OK" curl_onlyifcached_postitive_head
+    '
+		*/
 		{
 			Name: "HEAD for /ipfs/ with only-if-cached succeeds when in local datastore",
 			Request: Request().
@@ -100,6 +276,13 @@ func TestGatewayCache(t *testing.T) {
 			Response: Expect().
 				Status(200),
 		},
+		/*
+		test_expect_success "HEAD for /ipfs/ with only-if-cached fails when not in local datastore" '
+    curl -sv -I -H "Cache-Control: only-if-cached" "http://127.0.0.1:$GWAY_PORT/ipfs/$(date | ipfs add --only-hash -Q)" > curl_onlyifcached_negative_head 2>&1 &&
+    cat curl_onlyifcached_negative_head &&
+    grep "< HTTP/1.1 412 Precondition Failed" curl_onlyifcached_negative_head
+    '
+		*/
 		{
 			Name: "HEAD for /ipfs/ with only-if-cached fails when not in local datastore",
 			Request: Request().
@@ -111,6 +294,13 @@ func TestGatewayCache(t *testing.T) {
 			Response: Expect().
 				Status(412),
 		},
+		/*
+		test_expect_success "GET for /ipfs/ with only-if-cached succeeds when in local datastore" '
+    curl -svX GET -H "Cache-Control: only-if-cached" "http://127.0.0.1:$GWAY_PORT/ipfs/$ROOT1_CID/root2/root3/root4/index.html" >/dev/null 2>curl_onlyifcached_postitive_out &&
+    cat curl_onlyifcached_postitive_out &&
+    grep "< HTTP/1.1 200 OK" curl_onlyifcached_postitive_out
+    '
+		*/
 		{
 			Name: "GET for /ipfs/ with only-if-cached succeeds when in local datastore",
 			Request: Request().
@@ -121,6 +311,13 @@ func TestGatewayCache(t *testing.T) {
 			Response: Expect().
 				Status(200),
 		},
+		/*
+		test_expect_success "GET for /ipfs/ with only-if-cached fails when not in local datastore" '
+    curl -svX GET -H "Cache-Control: only-if-cached" "http://127.0.0.1:$GWAY_PORT/ipfs/$(date | ipfs add --only-hash -Q)" >/dev/null 2>curl_onlyifcached_negative_out &&
+    cat curl_onlyifcached_negative_out &&
+    grep "< HTTP/1.1 412 Precondition Failed" curl_onlyifcached_negative_out
+    '
+		*/
 		{
 			Name: "GET for /ipfs/ with only-if-cached fails when not in local datastore",
 			Request: Request().
@@ -131,6 +328,12 @@ func TestGatewayCache(t *testing.T) {
 			Response: Expect().
 				Status(412),
 		},
+		/*
+		test_expect_success "GET for /ipfs/ file with matching Etag in If-None-Match returns 304 Not Modified" '
+    curl -svX GET -H "If-None-Match: \"$FILE_CID\"" "http://127.0.0.1:$GWAY_PORT/ipfs/$ROOT1_CID/root2/root3/root4/index.html" >/dev/null 2>curl_output &&
+    test_should_contain "304 Not Modified" curl_output
+    '
+		*/
 		{
 			Name: "GET for /ipfs/ file with matching Etag in If-None-Match returns 304 Not Modified",
 			Request: Request().
@@ -141,6 +344,12 @@ func TestGatewayCache(t *testing.T) {
 			Response: Expect().
 				Status(304),
 		},
+		/*
+		test_expect_success "GET for /ipfs/ dir with index.html file with matching Etag in If-None-Match returns 304 Not Modified" '
+    curl -svX GET -H "If-None-Match: \"$ROOT4_CID\"" "http://127.0.0.1:$GWAY_PORT/ipfs/$ROOT1_CID/root2/root3/root4/" >/dev/null 2>curl_output &&
+    test_should_contain "304 Not Modified" curl_output
+    '
+		*/
 		{
 			Name: "GET for /ipfs/ dir with index.html file with matching Etag in If-None-Match returns 304 Not Modified",
 			Request: Request().
@@ -151,6 +360,12 @@ func TestGatewayCache(t *testing.T) {
 			Response: Expect().
 				Status(304),
 		},
+		/*
+		test_expect_success "GET for /ipfs/ file with matching third Etag in If-None-Match returns 304 Not Modified" '
+    curl -svX GET -H "If-None-Match: \"fakeEtag1\", \"fakeEtag2\", \"$FILE_CID\"" "http://127.0.0.1:$GWAY_PORT/ipfs/$ROOT1_CID/root2/root3/root4/index.html" >/dev/null 2>curl_output &&
+    test_should_contain "304 Not Modified" curl_output
+    '
+		*/
 		{
 			Name: "GET for /ipfs/ file with matching third Etag in If-None-Match returns 304 Not Modified",
 			Request: Request().
@@ -161,6 +376,12 @@ func TestGatewayCache(t *testing.T) {
 			Response: Expect().
 				Status(304),
 		},
+		/*
+		test_expect_success "GET for /ipfs/ file with matching weak Etag in If-None-Match returns 304 Not Modified" '
+    curl -svX GET -H "If-None-Match: W/\"$FILE_CID\"" "http://127.0.0.1:$GWAY_PORT/ipfs/$ROOT1_CID/root2/root3/root4/index.html" >/dev/null 2>curl_output &&
+    test_should_contain "304 Not Modified" curl_output
+    '
+		*/
 		{
 			Name: "GET for /ipfs/ file with matching weak Etag in If-None-Match returns 304 Not Modified",
 			Request: Request().
@@ -171,6 +392,12 @@ func TestGatewayCache(t *testing.T) {
 			Response: Expect().
 				Status(304),
 		},
+		/*
+		test_expect_success "GET for /ipfs/ file with wildcard Etag in If-None-Match returns 304 Not Modified" '
+    curl -svX GET -H "If-None-Match: *" "http://127.0.0.1:$GWAY_PORT/ipfs/$ROOT1_CID/root2/root3/root4/index.html" >/dev/null 2>curl_output &&
+    test_should_contain "304 Not Modified" curl_output
+    '
+		*/
 		{
 			Name: "GET for /ipfs/ file with wildcard Etag in If-None-Match returns 304 Not Modified",
 			Request: Request().
@@ -181,6 +408,12 @@ func TestGatewayCache(t *testing.T) {
 			Response: Expect().
 				Status(304),
 		},
+		/*
+		test_expect_success "GET for /ipfs/ dir listing with matching weak Etag in If-None-Match returns 304 Not Modified" '
+    curl -svX GET -H "If-None-Match: W/\"$ROOT3_CID\"" "http://127.0.0.1:$GWAY_PORT/ipfs/$ROOT1_CID/root2/root3/" >/dev/null 2>curl_output &&
+    test_should_contain "304 Not Modified" curl_output
+    '
+		*/
 		{
 			Name: "GET for /ipfs/ dir listing with matching weak Etag in If-None-Match returns 304 Not Modified",
 			Request: Request().

--- a/tests/t0116_gateway_cache_test.go
+++ b/tests/t0116_gateway_cache_test.go
@@ -11,8 +11,13 @@ import (
 func TestGatewayCache(t *testing.T) {
 	fixture := car.MustOpenUnixfsCar("t0116-gateway-cache.car")
 
-	var ipnsId string
-	var etag string
+	// TODO: Add ipns record support to fixtures and enable the ipns tests
+	// https://specs.ipfs.tech/http-gateways/path-gateway/#get-ipns-name-path-params
+	// var ipnsId string
+
+	// TODO: Add request chaining support to the test framework and enable the etag tests
+	// https://specs.ipfs.tech/http-gateways/path-gateway/#etag-response-header
+	// var etag string
 
 	tests := SugarTests{
 		{
@@ -192,6 +197,8 @@ func TestGatewayCache(t *testing.T) {
 			Response: Expect().
 				Status(304),
 		},
+		// The tests below require `ipnsId` to be set.
+		/*
 		{
 			Name: "GET for /ipns/ unixfs dir listing succeeds",
 			Request: Request().
@@ -277,6 +284,9 @@ func TestGatewayCache(t *testing.T) {
 			Response: Expect().
 				Status(304),
 		},
+		*/
+		// The tests below require `etag` to be set.
+		/*
 		{
 			Name: "GET for /ipfs/ dir listing with matching strong Etag in If-None-Match returns 304 Not Modified",
 			Request: Request().
@@ -297,6 +307,7 @@ func TestGatewayCache(t *testing.T) {
 			Response: Expect().
 				Status(304),
 		},
+		*/
 	}.Build()
 
 	Run(t, tests)

--- a/tests/t0116_gateway_cache_test.go
+++ b/tests/t0116_gateway_cache_test.go
@@ -8,113 +8,30 @@ import (
 	. "github.com/ipfs/gateway-conformance/tooling/test"
 )
 
-/* TODO
-1.
-test_expect_success "GET for /ipns/ unixfs dir listing succeeds" '
-curl -svX GET "http://127.0.0.1:$GWAY_PORT/ipns/$TEST_IPNS_ID/root2/root3/" >/dev/null 2>curl_ipns_dir_listing_output
-'
-test_expect_success "GET /ipns/ unixfs dir listing has no Cache-Control" '
-test_should_not_contain "< Cache-Control" curl_ipns_dir_listing_output
-'
-test_expect_success "GET /ipns/ unixfs dir listing has no Cache-Control" '
-test_should_not_contain "< Cache-Control" curl_ipns_dir_listing_output
-'
-test_expect_success "GET /ipns/ dir listing response has original content path in X-Ipfs-Path" '
-test_should_contain "< X-Ipfs-Path: /ipns/$TEST_IPNS_ID/root2/root3" curl_ipns_dir_listing_output
-'
-test_expect_success "GET /ipns/ dir listing response has logical CID roots in X-Ipfs-Roots" '
-test_should_contain "< X-Ipfs-Roots: ${ROOT1_CID},${ROOT2_CID},${ROOT3_CID}" curl_ipns_dir_listing_output
-'
-test_expect_success "GET /ipns/ dir response has special Etag for generated dir listing" '
-test_should_contain "< Etag: \"DirIndex" curl_ipns_dir_listing_output &&
-grep -E "< Etag: \"DirIndex-.+_CID-${ROOT3_CID}\"" curl_ipns_dir_listing_output
-'
-2.
-test_expect_success "GET for /ipns/ unixfs dir with index.html succeeds" '
-curl -svX GET "http://127.0.0.1:$GWAY_PORT/ipns/$TEST_IPNS_ID/root2/root3/root4/" >/dev/null 2>curl_ipns_dir_index.html_output
-'
-test_expect_success "GET /ipns/ unixfs dir with index.html has no Cache-Control" '
-test_should_not_contain "< Cache-Control" curl_ipns_dir_index.html_output
-'
-test_expect_success "GET /ipns/ dir index.html response has original content path in X-Ipfs-Path" '
-test_should_contain "< X-Ipfs-Path: /ipns/$TEST_IPNS_ID/root2/root3/root4/" curl_ipns_dir_index.html_output
-'
-test_expect_success "GET /ipns/ dir index.html response has logical CID roots in X-Ipfs-Roots" '
-test_should_contain "< X-Ipfs-Roots: ${ROOT1_CID},${ROOT2_CID},${ROOT3_CID},${ROOT4_CID}" curl_ipns_dir_index.html_output
-'
-test_expect_success "GET /ipns/ dir index.html response has dir CID as Etag" '
-test_should_contain "< Etag: \"${ROOT4_CID}\"" curl_ipns_dir_index.html_output
-'
-3.
-test_expect_success "GET for /ipns/ unixfs file succeeds" '
-curl -svX GET "http://127.0.0.1:$GWAY_PORT/ipns/$TEST_IPNS_ID/root2/root3/root4/index.html" >/dev/null 2>curl_ipns_file_output
-'
-test_expect_success "GET /ipns/ unixfs file has no Cache-Control" '
-test_should_not_contain "< Cache-Control" curl_ipns_file_output
-'
-test_expect_success "GET /ipns/ file response has original content path in X-Ipfs-Path" '
-test_should_contain "< X-Ipfs-Path: /ipns/$TEST_IPNS_ID/root2/root3/root4/index.html" curl_ipns_file_output
-'
-test_expect_success "GET /ipns/ file response has logical CID roots in X-Ipfs-Roots" '
-test_should_contain "< X-Ipfs-Roots: ${ROOT1_CID},${ROOT2_CID},${ROOT3_CID},${ROOT4_CID},${FILE_CID}" curl_ipns_file_output
-'
-test_expect_success "GET /ipns/ response has CID as Etag for a file" '
-test_should_contain "< Etag: \"${FILE_CID}\"" curl_ipns_file_output
-'
-4.
-test_expect_success "GET for /ipns/ unixfs dir as DAG-JSON succeeds" '
-curl -svX GET "http://127.0.0.1:$GWAY_PORT/ipns/$TEST_IPNS_ID/root2/root3/root4/?format=dag-json" >/dev/null 2>curl_ipns_dir_dag-json_output
-'
-test_expect_success "GET /ipns/ unixfs dir as dag-json has no Cache-Control" '
-test_should_not_contain "< Cache-Control" curl_ipns_dir_dag-json_output
-'
-5.
-test_expect_success "GET for /ipns/ unixfs dir as DAG-JSON succeeds" '
-curl -svX GET "http://127.0.0.1:$GWAY_PORT/ipns/$TEST_IPNS_ID/root2/root3/root4/?format=json" >/dev/null 2>curl_ipns_dir_json_output
-'
-test_expect_success "GET /ipns/ unixfs dir as json has no Cache-Control" '
-test_should_not_contain "< Cache-Control" curl_ipns_dir_json_output
-'
-6.
-test_expect_success "GET for /ipns/ file with matching Etag in If-None-Match returns 304 Not Modified" '
-curl -svX GET -H "If-None-Match: \"$FILE_CID\"" "http://127.0.0.1:$GWAY_PORT/ipns/$TEST_IPNS_ID/root2/root3/root4/index.html" >/dev/null 2>curl_output &&
-test_should_contain "304 Not Modified" curl_output
-'
-7.
-# DirIndex etag is based on xxhash(./assets/dir-index-html), so we need to fetch it dynamically
-test_expect_success "GET for /ipfs/ dir listing with matching strong Etag in If-None-Match returns 304 Not Modified" '
-curl -Is "http://127.0.0.1:$GWAY_PORT/ipfs/$ROOT1_CID/root2/root3/"| grep -i Etag | cut -f2- -d: | tr -d "[:space:]\"" > dir_index_etag &&
-curl -svX GET -H "If-None-Match: \"$(<dir_index_etag)\"" "http://127.0.0.1:$GWAY_PORT/ipfs/$ROOT1_CID/root2/root3/" >/dev/null 2>curl_output &&
-test_should_contain "304 Not Modified" curl_output
-'
-8.
-test_expect_success "GET for /ipfs/ dir listing with matching weak Etag in If-None-Match returns 304 Not Modified" '
-curl -Is "http://127.0.0.1:$GWAY_PORT/ipfs/$ROOT1_CID/root2/root3/"| grep -i Etag | cut -f2- -d: | tr -d "[:space:]\"" > dir_index_etag &&
-curl -svX GET -H "If-None-Match: W/\"$(<dir_index_etag)\"" "http://127.0.0.1:$GWAY_PORT/ipfs/$ROOT1_CID/root2/root3/" >/dev/null 2>curl_output &&
-test_should_contain "304 Not Modified" curl_output
-'
-*/
 func TestGatewayCache(t *testing.T) {
 	fixture := car.MustOpenUnixfsCar("t0116-gateway-cache.car")
 
+	var ipnsId string
+	var etag string
+
 	tests := SugarTests{
 		/*
-		test_expect_success "GET for /ipfs/ unixfs dir listing succeeds" '
-    curl -svX GET "http://127.0.0.1:$GWAY_PORT/ipfs/$ROOT1_CID/root2/root3/" >/dev/null 2>curl_ipfs_dir_listing_output
-    '
-		test_expect_success "GET /ipfs/ unixfs dir listing has no Cache-Control" '
-    test_should_not_contain "< Cache-Control" curl_ipfs_dir_listing_output
-    '
-		test_expect_success "GET /ipfs/ dir listing response has original content path in X-Ipfs-Path" '
-    test_should_contain "< X-Ipfs-Path: /ipfs/$ROOT1_CID/root2/root3" curl_ipfs_dir_listing_output
-    '
-		test_expect_success "GET /ipfs/ dir listing response has logical CID roots in X-Ipfs-Roots" '
-    test_should_contain "< X-Ipfs-Roots: ${ROOT1_CID},${ROOT2_CID},${ROOT3_CID}" curl_ipfs_dir_listing_output
-    '
-		test_expect_success "GET /ipfs/ dir response has special Etag for generated dir listing" '
-    test_should_contain "< Etag: \"DirIndex" curl_ipfs_dir_listing_output &&
-    grep -E "< Etag: \"DirIndex-.+_CID-${ROOT3_CID}\"" curl_ipfs_dir_listing_output
-    '
+					test_expect_success "GET for /ipfs/ unixfs dir listing succeeds" '
+			    curl -svX GET "http://127.0.0.1:$GWAY_PORT/ipfs/$ROOT1_CID/root2/root3/" >/dev/null 2>curl_ipfs_dir_listing_output
+			    '
+					test_expect_success "GET /ipfs/ unixfs dir listing has no Cache-Control" '
+			    test_should_not_contain "< Cache-Control" curl_ipfs_dir_listing_output
+			    '
+					test_expect_success "GET /ipfs/ dir listing response has original content path in X-Ipfs-Path" '
+			    test_should_contain "< X-Ipfs-Path: /ipfs/$ROOT1_CID/root2/root3" curl_ipfs_dir_listing_output
+			    '
+					test_expect_success "GET /ipfs/ dir listing response has logical CID roots in X-Ipfs-Roots" '
+			    test_should_contain "< X-Ipfs-Roots: ${ROOT1_CID},${ROOT2_CID},${ROOT3_CID}" curl_ipfs_dir_listing_output
+			    '
+					test_expect_success "GET /ipfs/ dir response has special Etag for generated dir listing" '
+			    test_should_contain "< Etag: \"DirIndex" curl_ipfs_dir_listing_output &&
+			    grep -E "< Etag: \"DirIndex-.+_CID-${ROOT3_CID}\"" curl_ipfs_dir_listing_output
+			    '
 		*/
 		{
 			Name: "GET for /ipfs/ unixfs dir listing succeeds",
@@ -134,21 +51,21 @@ func TestGatewayCache(t *testing.T) {
 				),
 		},
 		/*
-		test_expect_success "GET for /ipfs/ unixfs dir with index.html succeeds" '
-    curl -svX GET "http://127.0.0.1:$GWAY_PORT/ipfs/$ROOT1_CID/root2/root3/root4/" >/dev/null 2>curl_ipfs_dir_index.html_output
-    '
-    test_expect_success "GET /ipfs/ unixfs dir with index.html has expected Cache-Control" '
-    test_should_contain "< Cache-Control: public, max-age=29030400, immutable" curl_ipfs_dir_index.html_output
-    '
-		test_expect_success "GET /ipfs/ dir index.html response has original content path in X-Ipfs-Path" '
-    test_should_contain "< X-Ipfs-Path: /ipfs/$ROOT1_CID/root2/root3/root4/" curl_ipfs_dir_index.html_output
-    '
-		test_expect_success "GET /ipfs/ dir index.html response has logical CID roots in X-Ipfs-Roots" '
-    test_should_contain "< X-Ipfs-Roots: ${ROOT1_CID},${ROOT2_CID},${ROOT3_CID},${ROOT4_CID}" curl_ipfs_dir_index.html_output
-    '
-		test_expect_success "GET /ipfs/ dir index.html response has dir CID as Etag" '
-    test_should_contain "< Etag: \"${ROOT4_CID}\"" curl_ipfs_dir_index.html_output
-    '
+					test_expect_success "GET for /ipfs/ unixfs dir with index.html succeeds" '
+			    curl -svX GET "http://127.0.0.1:$GWAY_PORT/ipfs/$ROOT1_CID/root2/root3/root4/" >/dev/null 2>curl_ipfs_dir_index.html_output
+			    '
+			    test_expect_success "GET /ipfs/ unixfs dir with index.html has expected Cache-Control" '
+			    test_should_contain "< Cache-Control: public, max-age=29030400, immutable" curl_ipfs_dir_index.html_output
+			    '
+					test_expect_success "GET /ipfs/ dir index.html response has original content path in X-Ipfs-Path" '
+			    test_should_contain "< X-Ipfs-Path: /ipfs/$ROOT1_CID/root2/root3/root4/" curl_ipfs_dir_index.html_output
+			    '
+					test_expect_success "GET /ipfs/ dir index.html response has logical CID roots in X-Ipfs-Roots" '
+			    test_should_contain "< X-Ipfs-Roots: ${ROOT1_CID},${ROOT2_CID},${ROOT3_CID},${ROOT4_CID}" curl_ipfs_dir_index.html_output
+			    '
+					test_expect_success "GET /ipfs/ dir index.html response has dir CID as Etag" '
+			    test_should_contain "< Etag: \"${ROOT4_CID}\"" curl_ipfs_dir_index.html_output
+			    '
 		*/
 		{
 			Name: "GET for /ipfs/ unixfs dir with index.html succeeds",
@@ -168,21 +85,21 @@ func TestGatewayCache(t *testing.T) {
 				),
 		},
 		/*
-		test_expect_success "GET for /ipfs/ unixfs file succeeds" '
-    curl -svX GET "http://127.0.0.1:$GWAY_PORT/ipfs/$ROOT1_CID/root2/root3/root4/index.html" >/dev/null 2>curl_ipfs_file_output
-    '
-		test_expect_success "GET /ipfs/ unixfs file has expected Cache-Control" '
-    test_should_contain "< Cache-Control: public, max-age=29030400, immutable" curl_ipfs_file_output
-    '
-		test_expect_success "GET /ipfs/ file response has original content path in X-Ipfs-Path" '
-    test_should_contain "< X-Ipfs-Path: /ipfs/$ROOT1_CID/root2/root3/root4/index.html" curl_ipfs_file_output
-    '
-		test_expect_success "GET /ipfs/ file response has logical CID roots in X-Ipfs-Roots" '
-    test_should_contain "< X-Ipfs-Roots: ${ROOT1_CID},${ROOT2_CID},${ROOT3_CID},${ROOT4_CID},${FILE_CID}" curl_ipfs_file_output
-    '
-		test_expect_success "GET /ipfs/ response has CID as Etag for a file" '
-    test_should_contain "< Etag: \"${FILE_CID}\"" curl_ipfs_file_output
-    '
+					test_expect_success "GET for /ipfs/ unixfs file succeeds" '
+			    curl -svX GET "http://127.0.0.1:$GWAY_PORT/ipfs/$ROOT1_CID/root2/root3/root4/index.html" >/dev/null 2>curl_ipfs_file_output
+			    '
+					test_expect_success "GET /ipfs/ unixfs file has expected Cache-Control" '
+			    test_should_contain "< Cache-Control: public, max-age=29030400, immutable" curl_ipfs_file_output
+			    '
+					test_expect_success "GET /ipfs/ file response has original content path in X-Ipfs-Path" '
+			    test_should_contain "< X-Ipfs-Path: /ipfs/$ROOT1_CID/root2/root3/root4/index.html" curl_ipfs_file_output
+			    '
+					test_expect_success "GET /ipfs/ file response has logical CID roots in X-Ipfs-Roots" '
+			    test_should_contain "< X-Ipfs-Roots: ${ROOT1_CID},${ROOT2_CID},${ROOT3_CID},${ROOT4_CID},${FILE_CID}" curl_ipfs_file_output
+			    '
+					test_expect_success "GET /ipfs/ response has CID as Etag for a file" '
+			    test_should_contain "< Etag: \"${FILE_CID}\"" curl_ipfs_file_output
+			    '
 		*/
 		{
 			Name: "GET for /ipfs/ unixfs file succeeds",
@@ -202,12 +119,12 @@ func TestGatewayCache(t *testing.T) {
 				),
 		},
 		/*
-		test_expect_success "GET for /ipfs/ unixfs dir as DAG-JSON succeeds" '
-    curl -svX GET "http://127.0.0.1:$GWAY_PORT/ipfs/$ROOT1_CID/root2/root3/root4/?format=dag-json" >/dev/null 2>curl_ipfs_dir_dag-json_output
-    '
-    test_expect_success "GET /ipfs/ dag-json has expected Cache-Control" '
-    test_should_contain "< Cache-Control: public, max-age=29030400, immutable" curl_ipfs_dir_dag-json_output
-    '
+					test_expect_success "GET for /ipfs/ unixfs dir as DAG-JSON succeeds" '
+			    curl -svX GET "http://127.0.0.1:$GWAY_PORT/ipfs/$ROOT1_CID/root2/root3/root4/?format=dag-json" >/dev/null 2>curl_ipfs_dir_dag-json_output
+			    '
+			    test_expect_success "GET /ipfs/ dag-json has expected Cache-Control" '
+			    test_should_contain "< Cache-Control: public, max-age=29030400, immutable" curl_ipfs_dir_dag-json_output
+			    '
 		*/
 		{
 			Name: "GET for /ipfs/ unixfs dir as DAG-JSON succeeds",
@@ -222,12 +139,12 @@ func TestGatewayCache(t *testing.T) {
 				),
 		},
 		/*
-		test_expect_success "GET for /ipfs/ unixfs dir as DAG-JSON succeeds" '
-    curl -svX GET "http://127.0.0.1:$GWAY_PORT/ipfs/$ROOT1_CID/root2/root3/root4/?format=json" >/dev/null 2>curl_ipfs_dir_json_output
-    '
-    test_expect_success "GET /ipfs/ unixfs dir as json has expected Cache-Control" '
-    test_should_contain "< Cache-Control: public, max-age=29030400, immutable" curl_ipfs_dir_json_output
-    '
+					test_expect_success "GET for /ipfs/ unixfs dir as DAG-JSON succeeds" '
+			    curl -svX GET "http://127.0.0.1:$GWAY_PORT/ipfs/$ROOT1_CID/root2/root3/root4/?format=json" >/dev/null 2>curl_ipfs_dir_json_output
+			    '
+			    test_expect_success "GET /ipfs/ unixfs dir as json has expected Cache-Control" '
+			    test_should_contain "< Cache-Control: public, max-age=29030400, immutable" curl_ipfs_dir_json_output
+			    '
 		*/
 		{
 			Name: "GET for /ipfs/ unixfs dir as JSON succeeds",
@@ -242,11 +159,11 @@ func TestGatewayCache(t *testing.T) {
 				),
 		},
 		/*
-		test_expect_success "HEAD for /ipfs/ with only-if-cached succeeds when in local datastore" '
-    curl -sv -I -H "Cache-Control: only-if-cached" "http://127.0.0.1:$GWAY_PORT/ipfs/$ROOT1_CID/root2/root3/root4/index.html" > curl_onlyifcached_postitive_head 2>&1 &&
-    cat curl_onlyifcached_postitive_head &&
-    grep "< HTTP/1.1 200 OK" curl_onlyifcached_postitive_head
-    '
+					test_expect_success "HEAD for /ipfs/ with only-if-cached succeeds when in local datastore" '
+			    curl -sv -I -H "Cache-Control: only-if-cached" "http://127.0.0.1:$GWAY_PORT/ipfs/$ROOT1_CID/root2/root3/root4/index.html" > curl_onlyifcached_postitive_head 2>&1 &&
+			    cat curl_onlyifcached_postitive_head &&
+			    grep "< HTTP/1.1 200 OK" curl_onlyifcached_postitive_head
+			    '
 		*/
 		{
 			Name: "HEAD for /ipfs/ with only-if-cached succeeds when in local datastore",
@@ -260,11 +177,11 @@ func TestGatewayCache(t *testing.T) {
 				Status(200),
 		},
 		/*
-		test_expect_success "HEAD for /ipfs/ with only-if-cached fails when not in local datastore" '
-    curl -sv -I -H "Cache-Control: only-if-cached" "http://127.0.0.1:$GWAY_PORT/ipfs/$(date | ipfs add --only-hash -Q)" > curl_onlyifcached_negative_head 2>&1 &&
-    cat curl_onlyifcached_negative_head &&
-    grep "< HTTP/1.1 412 Precondition Failed" curl_onlyifcached_negative_head
-    '
+					test_expect_success "HEAD for /ipfs/ with only-if-cached fails when not in local datastore" '
+			    curl -sv -I -H "Cache-Control: only-if-cached" "http://127.0.0.1:$GWAY_PORT/ipfs/$(date | ipfs add --only-hash -Q)" > curl_onlyifcached_negative_head 2>&1 &&
+			    cat curl_onlyifcached_negative_head &&
+			    grep "< HTTP/1.1 412 Precondition Failed" curl_onlyifcached_negative_head
+			    '
 		*/
 		{
 			Name: "HEAD for /ipfs/ with only-if-cached fails when not in local datastore",
@@ -278,11 +195,11 @@ func TestGatewayCache(t *testing.T) {
 				Status(412),
 		},
 		/*
-		test_expect_success "GET for /ipfs/ with only-if-cached succeeds when in local datastore" '
-    curl -svX GET -H "Cache-Control: only-if-cached" "http://127.0.0.1:$GWAY_PORT/ipfs/$ROOT1_CID/root2/root3/root4/index.html" >/dev/null 2>curl_onlyifcached_postitive_out &&
-    cat curl_onlyifcached_postitive_out &&
-    grep "< HTTP/1.1 200 OK" curl_onlyifcached_postitive_out
-    '
+					test_expect_success "GET for /ipfs/ with only-if-cached succeeds when in local datastore" '
+			    curl -svX GET -H "Cache-Control: only-if-cached" "http://127.0.0.1:$GWAY_PORT/ipfs/$ROOT1_CID/root2/root3/root4/index.html" >/dev/null 2>curl_onlyifcached_postitive_out &&
+			    cat curl_onlyifcached_postitive_out &&
+			    grep "< HTTP/1.1 200 OK" curl_onlyifcached_postitive_out
+			    '
 		*/
 		{
 			Name: "GET for /ipfs/ with only-if-cached succeeds when in local datastore",
@@ -295,11 +212,11 @@ func TestGatewayCache(t *testing.T) {
 				Status(200),
 		},
 		/*
-		test_expect_success "GET for /ipfs/ with only-if-cached fails when not in local datastore" '
-    curl -svX GET -H "Cache-Control: only-if-cached" "http://127.0.0.1:$GWAY_PORT/ipfs/$(date | ipfs add --only-hash -Q)" >/dev/null 2>curl_onlyifcached_negative_out &&
-    cat curl_onlyifcached_negative_out &&
-    grep "< HTTP/1.1 412 Precondition Failed" curl_onlyifcached_negative_out
-    '
+					test_expect_success "GET for /ipfs/ with only-if-cached fails when not in local datastore" '
+			    curl -svX GET -H "Cache-Control: only-if-cached" "http://127.0.0.1:$GWAY_PORT/ipfs/$(date | ipfs add --only-hash -Q)" >/dev/null 2>curl_onlyifcached_negative_out &&
+			    cat curl_onlyifcached_negative_out &&
+			    grep "< HTTP/1.1 412 Precondition Failed" curl_onlyifcached_negative_out
+			    '
 		*/
 		{
 			Name: "GET for /ipfs/ with only-if-cached fails when not in local datastore",
@@ -312,10 +229,10 @@ func TestGatewayCache(t *testing.T) {
 				Status(412),
 		},
 		/*
-		test_expect_success "GET for /ipfs/ file with matching Etag in If-None-Match returns 304 Not Modified" '
-    curl -svX GET -H "If-None-Match: \"$FILE_CID\"" "http://127.0.0.1:$GWAY_PORT/ipfs/$ROOT1_CID/root2/root3/root4/index.html" >/dev/null 2>curl_output &&
-    test_should_contain "304 Not Modified" curl_output
-    '
+					test_expect_success "GET for /ipfs/ file with matching Etag in If-None-Match returns 304 Not Modified" '
+			    curl -svX GET -H "If-None-Match: \"$FILE_CID\"" "http://127.0.0.1:$GWAY_PORT/ipfs/$ROOT1_CID/root2/root3/root4/index.html" >/dev/null 2>curl_output &&
+			    test_should_contain "304 Not Modified" curl_output
+			    '
 		*/
 		{
 			Name: "GET for /ipfs/ file with matching Etag in If-None-Match returns 304 Not Modified",
@@ -328,10 +245,10 @@ func TestGatewayCache(t *testing.T) {
 				Status(304),
 		},
 		/*
-		test_expect_success "GET for /ipfs/ dir with index.html file with matching Etag in If-None-Match returns 304 Not Modified" '
-    curl -svX GET -H "If-None-Match: \"$ROOT4_CID\"" "http://127.0.0.1:$GWAY_PORT/ipfs/$ROOT1_CID/root2/root3/root4/" >/dev/null 2>curl_output &&
-    test_should_contain "304 Not Modified" curl_output
-    '
+					test_expect_success "GET for /ipfs/ dir with index.html file with matching Etag in If-None-Match returns 304 Not Modified" '
+			    curl -svX GET -H "If-None-Match: \"$ROOT4_CID\"" "http://127.0.0.1:$GWAY_PORT/ipfs/$ROOT1_CID/root2/root3/root4/" >/dev/null 2>curl_output &&
+			    test_should_contain "304 Not Modified" curl_output
+			    '
 		*/
 		{
 			Name: "GET for /ipfs/ dir with index.html file with matching Etag in If-None-Match returns 304 Not Modified",
@@ -344,10 +261,10 @@ func TestGatewayCache(t *testing.T) {
 				Status(304),
 		},
 		/*
-		test_expect_success "GET for /ipfs/ file with matching third Etag in If-None-Match returns 304 Not Modified" '
-    curl -svX GET -H "If-None-Match: \"fakeEtag1\", \"fakeEtag2\", \"$FILE_CID\"" "http://127.0.0.1:$GWAY_PORT/ipfs/$ROOT1_CID/root2/root3/root4/index.html" >/dev/null 2>curl_output &&
-    test_should_contain "304 Not Modified" curl_output
-    '
+					test_expect_success "GET for /ipfs/ file with matching third Etag in If-None-Match returns 304 Not Modified" '
+			    curl -svX GET -H "If-None-Match: \"fakeEtag1\", \"fakeEtag2\", \"$FILE_CID\"" "http://127.0.0.1:$GWAY_PORT/ipfs/$ROOT1_CID/root2/root3/root4/index.html" >/dev/null 2>curl_output &&
+			    test_should_contain "304 Not Modified" curl_output
+			    '
 		*/
 		{
 			Name: "GET for /ipfs/ file with matching third Etag in If-None-Match returns 304 Not Modified",
@@ -360,10 +277,10 @@ func TestGatewayCache(t *testing.T) {
 				Status(304),
 		},
 		/*
-		test_expect_success "GET for /ipfs/ file with matching weak Etag in If-None-Match returns 304 Not Modified" '
-    curl -svX GET -H "If-None-Match: W/\"$FILE_CID\"" "http://127.0.0.1:$GWAY_PORT/ipfs/$ROOT1_CID/root2/root3/root4/index.html" >/dev/null 2>curl_output &&
-    test_should_contain "304 Not Modified" curl_output
-    '
+					test_expect_success "GET for /ipfs/ file with matching weak Etag in If-None-Match returns 304 Not Modified" '
+			    curl -svX GET -H "If-None-Match: W/\"$FILE_CID\"" "http://127.0.0.1:$GWAY_PORT/ipfs/$ROOT1_CID/root2/root3/root4/index.html" >/dev/null 2>curl_output &&
+			    test_should_contain "304 Not Modified" curl_output
+			    '
 		*/
 		{
 			Name: "GET for /ipfs/ file with matching weak Etag in If-None-Match returns 304 Not Modified",
@@ -376,10 +293,10 @@ func TestGatewayCache(t *testing.T) {
 				Status(304),
 		},
 		/*
-		test_expect_success "GET for /ipfs/ file with wildcard Etag in If-None-Match returns 304 Not Modified" '
-    curl -svX GET -H "If-None-Match: *" "http://127.0.0.1:$GWAY_PORT/ipfs/$ROOT1_CID/root2/root3/root4/index.html" >/dev/null 2>curl_output &&
-    test_should_contain "304 Not Modified" curl_output
-    '
+					test_expect_success "GET for /ipfs/ file with wildcard Etag in If-None-Match returns 304 Not Modified" '
+			    curl -svX GET -H "If-None-Match: *" "http://127.0.0.1:$GWAY_PORT/ipfs/$ROOT1_CID/root2/root3/root4/index.html" >/dev/null 2>curl_output &&
+			    test_should_contain "304 Not Modified" curl_output
+			    '
 		*/
 		{
 			Name: "GET for /ipfs/ file with wildcard Etag in If-None-Match returns 304 Not Modified",
@@ -392,10 +309,10 @@ func TestGatewayCache(t *testing.T) {
 				Status(304),
 		},
 		/*
-		test_expect_success "GET for /ipfs/ dir listing with matching weak Etag in If-None-Match returns 304 Not Modified" '
-    curl -svX GET -H "If-None-Match: W/\"$ROOT3_CID\"" "http://127.0.0.1:$GWAY_PORT/ipfs/$ROOT1_CID/root2/root3/" >/dev/null 2>curl_output &&
-    test_should_contain "304 Not Modified" curl_output
-    '
+					test_expect_success "GET for /ipfs/ dir listing with matching weak Etag in If-None-Match returns 304 Not Modified" '
+			    curl -svX GET -H "If-None-Match: W/\"$ROOT3_CID\"" "http://127.0.0.1:$GWAY_PORT/ipfs/$ROOT1_CID/root2/root3/" >/dev/null 2>curl_output &&
+			    test_should_contain "304 Not Modified" curl_output
+			    '
 		*/
 		{
 			Name: "GET for /ipfs/ dir listing with matching weak Etag in If-None-Match returns 304 Not Modified",
@@ -403,6 +320,203 @@ func TestGatewayCache(t *testing.T) {
 				Path("ipfs/%s/root2/root3/", fixture.MustGetCid()).
 				Headers(
 					Header("If-None-Match", fmt.Sprintf("W/\"%s\"", fixture.MustGetCid("root2", "root3"))),
+				),
+			Response: Expect().
+				Status(304),
+		},
+		/*
+			test_expect_success "GET for /ipns/ unixfs dir listing succeeds" '
+			curl -svX GET "http://127.0.0.1:$GWAY_PORT/ipns/$TEST_IPNS_ID/root2/root3/" >/dev/null 2>curl_ipns_dir_listing_output
+			'
+			test_expect_success "GET /ipns/ unixfs dir listing has no Cache-Control" '
+			test_should_not_contain "< Cache-Control" curl_ipns_dir_listing_output
+			'
+			test_expect_success "GET /ipns/ unixfs dir listing has no Cache-Control" '
+			test_should_not_contain "< Cache-Control" curl_ipns_dir_listing_output
+			'
+			test_expect_success "GET /ipns/ dir listing response has original content path in X-Ipfs-Path" '
+			test_should_contain "< X-Ipfs-Path: /ipns/$TEST_IPNS_ID/root2/root3" curl_ipns_dir_listing_output
+			'
+			test_expect_success "GET /ipns/ dir listing response has logical CID roots in X-Ipfs-Roots" '
+			test_should_contain "< X-Ipfs-Roots: ${ROOT1_CID},${ROOT2_CID},${ROOT3_CID}" curl_ipns_dir_listing_output
+			'
+			test_expect_success "GET /ipns/ dir response has special Etag for generated dir listing" '
+			test_should_contain "< Etag: \"DirIndex" curl_ipns_dir_listing_output &&
+			grep -E "< Etag: \"DirIndex-.+_CID-${ROOT3_CID}\"" curl_ipns_dir_listing_output
+			'
+		*/
+		{
+			Name: "GET for /ipns/ unixfs dir listing succeeds",
+			Request: Request().
+				Path("ipns/%s/root2/root3/", ipnsId),
+			Response: Expect().
+				Status(200).
+				Headers(
+					Header("Cache-Control").
+						IsEmpty(),
+					Header("X-Ipfs-Path").
+						Equals("/ipns/%s/root2/root3", ipnsId),
+					Header("X-Ipfs-Roots").
+						Equals("%s,%s,%s", fixture.MustGetCid(), fixture.MustGetCid("root2"), fixture.MustGetCid("root2", "root3")),
+					Header("Etag").
+						Matches("DirIndex-.*_CID-%s", fixture.MustGetCid("root2", "root3")),
+				),
+		},
+		/*
+			test_expect_success "GET for /ipns/ unixfs dir with index.html succeeds" '
+			curl -svX GET "http://127.0.0.1:$GWAY_PORT/ipns/$TEST_IPNS_ID/root2/root3/root4/" >/dev/null 2>curl_ipns_dir_index.html_output
+			'
+			test_expect_success "GET /ipns/ unixfs dir with index.html has no Cache-Control" '
+			test_should_not_contain "< Cache-Control" curl_ipns_dir_index.html_output
+			'
+			test_expect_success "GET /ipns/ dir index.html response has original content path in X-Ipfs-Path" '
+			test_should_contain "< X-Ipfs-Path: /ipns/$TEST_IPNS_ID/root2/root3/root4/" curl_ipns_dir_index.html_output
+			'
+			test_expect_success "GET /ipns/ dir index.html response has logical CID roots in X-Ipfs-Roots" '
+			test_should_contain "< X-Ipfs-Roots: ${ROOT1_CID},${ROOT2_CID},${ROOT3_CID},${ROOT4_CID}" curl_ipns_dir_index.html_output
+			'
+			test_expect_success "GET /ipns/ dir index.html response has dir CID as Etag" '
+			test_should_contain "< Etag: \"${ROOT4_CID}\"" curl_ipns_dir_index.html_output
+			'
+		*/
+		{
+			Name: "GET for /ipns/ unixfs dir with index.html succeeds",
+			Request: Request().
+				Path("ipns/%s/root2/root3/root4/", ipnsId),
+			Response: Expect().
+				Status(200).
+				Headers(
+					Header("Cache-Control").
+						IsEmpty(),
+					Header("X-Ipfs-Path").
+						Equals("/ipns/%s/root2/root3/root4/", ipnsId),
+					Header("X-Ipfs-Roots").
+						Equals("%s,%s,%s,%s", fixture.MustGetCid(), fixture.MustGetCid("root2"), fixture.MustGetCid("root2", "root3"), fixture.MustGetCid("root2", "root3", "root4")),
+					Header("Etag").
+						Matches("DirIndex-.*_CID-%s", fixture.MustGetCid("root2", "root3", "root4")),
+				),
+		},
+		/*
+			test_expect_success "GET for /ipns/ unixfs file succeeds" '
+			curl -svX GET "http://127.0.0.1:$GWAY_PORT/ipns/$TEST_IPNS_ID/root2/root3/root4/index.html" >/dev/null 2>curl_ipns_file_output
+			'
+			test_expect_success "GET /ipns/ unixfs file has no Cache-Control" '
+			test_should_not_contain "< Cache-Control" curl_ipns_file_output
+			'
+			test_expect_success "GET /ipns/ file response has original content path in X-Ipfs-Path" '
+			test_should_contain "< X-Ipfs-Path: /ipns/$TEST_IPNS_ID/root2/root3/root4/index.html" curl_ipns_file_output
+			'
+			test_expect_success "GET /ipns/ file response has logical CID roots in X-Ipfs-Roots" '
+			test_should_contain "< X-Ipfs-Roots: ${ROOT1_CID},${ROOT2_CID},${ROOT3_CID},${ROOT4_CID},${FILE_CID}" curl_ipns_file_output
+			'
+			test_expect_success "GET /ipns/ response has CID as Etag for a file" '
+			test_should_contain "< Etag: \"${FILE_CID}\"" curl_ipns_file_output
+			'
+		*/
+		{
+			Name: "GET for /ipns/ unixfs file succeeds",
+			Request: Request().
+				Path("ipns/%s/root2/root3/root4/index.html", ipnsId),
+			Response: Expect().
+				Status(200).
+				Headers(
+					Header("Cache-Control").
+						Equals("public, max-age=29030400, immutable"),
+					Header("X-Ipfs-Path").
+						Equals("/ipns/%s/root2/root3/root4/index.html", ipnsId),
+					Header("X-Ipfs-Roots").
+						Equals("%s,%s,%s,%s,%s", fixture.MustGetCid(), fixture.MustGetCid("root2"), fixture.MustGetCid("root2", "root3"), fixture.MustGetCid("root2", "root3", "root4"), fixture.MustGetCid("root2", "root3", "root4", "index.html")),
+					Header("Etag").
+						Equals("\"%s\"", fixture.MustGetCid("root2", "root3", "root4", "index.html")),
+				),
+		},
+		/*
+			test_expect_success "GET for /ipns/ unixfs dir as DAG-JSON succeeds" '
+			curl -svX GET "http://127.0.0.1:$GWAY_PORT/ipns/$TEST_IPNS_ID/root2/root3/root4/?format=dag-json" >/dev/null 2>curl_ipns_dir_dag-json_output
+			'
+			test_expect_success "GET /ipns/ unixfs dir as dag-json has no Cache-Control" '
+			test_should_not_contain "< Cache-Control" curl_ipns_dir_dag-json_output
+			'
+		*/
+		{
+			Name: "GET for /ipns/ unixfs dir as DAG-JSON succeeds",
+			Request: Request().
+				Path("ipns/%s/root2/root3/root4/", ipnsId).
+				Query("format", "dag-json"),
+			Response: Expect().
+				Status(200).
+				Headers(
+					Header("Cache-Control").
+						Equals("public, max-age=29030400, immutable"),
+				),
+		},
+		/*
+			test_expect_success "GET for /ipns/ unixfs dir as DAG-JSON succeeds" '
+			curl -svX GET "http://127.0.0.1:$GWAY_PORT/ipns/$TEST_IPNS_ID/root2/root3/root4/?format=json" >/dev/null 2>curl_ipns_dir_json_output
+			'
+			test_expect_success "GET /ipns/ unixfs dir as json has no Cache-Control" '
+			test_should_not_contain "< Cache-Control" curl_ipns_dir_json_output
+			'
+		*/
+		{
+			Name: "GET for /ipns/ unixfs dir as JSON succeeds",
+			Request: Request().
+				Path("ipns/%s/root2/root3/root4/", ipnsId).
+				Query("format", "json"),
+			Response: Expect().
+				Status(200).
+				Headers(
+					Header("Cache-Control").
+						Equals("public, max-age=29030400, immutable"),
+				),
+		},
+		/*
+			test_expect_success "GET for /ipns/ file with matching Etag in If-None-Match returns 304 Not Modified" '
+			curl -svX GET -H "If-None-Match: \"$FILE_CID\"" "http://127.0.0.1:$GWAY_PORT/ipns/$TEST_IPNS_ID/root2/root3/root4/index.html" >/dev/null 2>curl_output &&
+			test_should_contain "304 Not Modified" curl_output
+			'
+		*/
+		{
+			Name: "GET for /ipns/ file with matching Etag in If-None-Match returns 304 Not Modified",
+			Request: Request().
+				Path("ipns/%s/root2/root3/root4/index.html", ipnsId).
+				Headers(
+					Header("If-None-Match", fmt.Sprintf("\"%s\"", fixture.MustGetCid("root2", "root3", "root4", "index.html"))),
+				),
+			Response: Expect().
+				Status(304),
+		},
+		/*
+			# DirIndex etag is based on xxhash(./assets/dir-index-html), so we need to fetch it dynamically
+			test_expect_success "GET for /ipfs/ dir listing with matching strong Etag in If-None-Match returns 304 Not Modified" '
+			curl -Is "http://127.0.0.1:$GWAY_PORT/ipfs/$ROOT1_CID/root2/root3/"| grep -i Etag | cut -f2- -d: | tr -d "[:space:]\"" > dir_index_etag &&
+			curl -svX GET -H "If-None-Match: \"$(<dir_index_etag)\"" "http://127.0.0.1:$GWAY_PORT/ipfs/$ROOT1_CID/root2/root3/" >/dev/null 2>curl_output &&
+			test_should_contain "304 Not Modified" curl_output
+			'
+		*/
+		{
+			Name: "GET for /ipfs/ dir listing with matching strong Etag in If-None-Match returns 304 Not Modified",
+			Request: Request().
+				Path("ipfs/%s/root2/root3/", fixture.MustGetCid()).
+				Headers(
+					Header("If-None-Match", fmt.Sprintf("\"%s\"", etag)),
+				),
+			Response: Expect().
+				Status(304),
+		},
+		/*
+			test_expect_success "GET for /ipfs/ dir listing with matching weak Etag in If-None-Match returns 304 Not Modified" '
+			curl -Is "http://127.0.0.1:$GWAY_PORT/ipfs/$ROOT1_CID/root2/root3/"| grep -i Etag | cut -f2- -d: | tr -d "[:space:]\"" > dir_index_etag &&
+			curl -svX GET -H "If-None-Match: W/\"$(<dir_index_etag)\"" "http://127.0.0.1:$GWAY_PORT/ipfs/$ROOT1_CID/root2/root3/" >/dev/null 2>curl_output &&
+			test_should_contain "304 Not Modified" curl_output
+			'
+		*/
+		{
+			Name: "GET for /ipfs/ dir listing with matching strong Etag in If-None-Match returns 304 Not Modified",
+			Request: Request().
+				Path("ipfs/%s/root2/root3/", fixture.MustGetCid()).
+				Headers(
+					Header("If-None-Match", fmt.Sprintf("W/\"%s\"", etag)),
 				),
 			Response: Expect().
 				Status(304),

--- a/tests/t0116_gateway_cache_test.go
+++ b/tests/t0116_gateway_cache_test.go
@@ -308,7 +308,7 @@ func TestGatewayCache(t *testing.T) {
 				Status(304),
 		},
 		*/
-	}.Build()
+	}
 
 	Run(t, tests)
 }

--- a/tests/t0116_gateway_cache_test.go
+++ b/tests/t0116_gateway_cache_test.go
@@ -1,6 +1,7 @@
 package tests
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/ipfs/gateway-conformance/tooling/car"
@@ -93,8 +94,7 @@ func TestGatewayCache(t *testing.T) {
 			Request: Request().
 				Path("ipfs/%s/root2/root3/root4/?format=json", fixture.MustGetCid()).
 				Headers(
-					Header("Cache-Control").
-						Equals("only-if-cached"),
+					Header("Cache-Control", "only-if-cached"),
 				).
 				Method("HEAD"),
 			Response: Expect().
@@ -105,8 +105,7 @@ func TestGatewayCache(t *testing.T) {
 			Request: Request().
 				Path("ipfs/QmYzfKSE55XCjD1MW128RfciAf2DViABhEiXfgVFMabSjN").
 				Headers(
-					Header("Cache-Control").
-						Equals("only-if-cached"),
+					Header("Cache-Control", "only-if-cached"),
 				).
 				Method("HEAD"),
 			Response: Expect().
@@ -117,8 +116,7 @@ func TestGatewayCache(t *testing.T) {
 			Request: Request().
 				Path("ipfs/%s/root2/root3/root4/?format=json", fixture.MustGetCid()).
 				Headers(
-					Header("Cache-Control").
-						Equals("only-if-cached"),
+					Header("Cache-Control", "only-if-cached"),
 				),
 			Response: Expect().
 				Status(200),
@@ -128,8 +126,7 @@ func TestGatewayCache(t *testing.T) {
 			Request: Request().
 				Path("ipfs/QmYzfKSE55XCjD1MW128RfciAf2DViABhEiXfgVFMabSjN").
 				Headers(
-					Header("Cache-Control").
-						Equals("only-if-cached"),
+					Header("Cache-Control", "only-if-cached"),
 				),
 			Response: Expect().
 				Status(412),
@@ -139,8 +136,7 @@ func TestGatewayCache(t *testing.T) {
 			Request: Request().
 				Path("ipfs/%s/root2/root3/root4/index.html", fixture.MustGetCid()).
 				Headers(
-					Header("If-None-Match").
-						Equals("\"%s\"", fixture.MustGetCid("root2", "root3", "root4", "index.html")),
+					Header("If-None-Match", fmt.Sprintf("\"%s\"", fixture.MustGetCid("root2", "root3", "root4", "index.html"))),
 				),
 			Response: Expect().
 				Status(304),
@@ -150,8 +146,7 @@ func TestGatewayCache(t *testing.T) {
 			Request: Request().
 				Path("ipfs/%s/root2/root3/root4/", fixture.MustGetCid()).
 				Headers(
-					Header("If-None-Match").
-						Equals("\"%s\"", fixture.MustGetCid("root2", "root3", "root4")),
+					Header("If-None-Match", fmt.Sprintf("\"%s\"", fixture.MustGetCid("root2", "root3", "root4"))),
 				),
 			Response: Expect().
 				Status(304),
@@ -161,8 +156,7 @@ func TestGatewayCache(t *testing.T) {
 			Request: Request().
 				Path("ipfs/%s/root2/root3/root4/index.html", fixture.MustGetCid()).
 				Headers(
-					Header("If-None-Match").
-						Equals("\"fakeEtag1\", \"fakeEtag2\", \"%s\"", fixture.MustGetCid("root2", "root3", "root4", "index.html")),
+					Header("If-None-Match", fmt.Sprintf("\"fakeEtag1\", \"fakeEtag2\", \"%s\"", fixture.MustGetCid("root2", "root3", "root4", "index.html"))),
 				),
 			Response: Expect().
 				Status(304),
@@ -172,8 +166,7 @@ func TestGatewayCache(t *testing.T) {
 			Request: Request().
 				Path("ipfs/%s/root2/root3/root4/index.html", fixture.MustGetCid()).
 				Headers(
-					Header("If-None-Match").
-						Equals("W/\"%s\"", fixture.MustGetCid("root2", "root3", "root4", "index.html")),
+					Header("If-None-Match", fmt.Sprintf("W/\"%s\"", fixture.MustGetCid("root2", "root3", "root4", "index.html"))),
 				),
 			Response: Expect().
 				Status(304),
@@ -183,8 +176,7 @@ func TestGatewayCache(t *testing.T) {
 			Request: Request().
 				Path("ipfs/%s/root2/root3/root4/index.html", fixture.MustGetCid()).
 				Headers(
-					Header("If-None-Match").
-						Equals("*"),
+					Header("If-None-Match", "*"),
 				),
 			Response: Expect().
 				Status(304),
@@ -194,8 +186,7 @@ func TestGatewayCache(t *testing.T) {
 			Request: Request().
 				Path("ipfs/%s/root2/root3/", fixture.MustGetCid()).
 				Headers(
-					Header("If-None-Match").
-						Equals("W/\"%s\"", fixture.MustGetCid("root2", "root3")),
+					Header("If-None-Match", fmt.Sprintf("W/\"%s\"", fixture.MustGetCid("root2", "root3"))),
 				),
 			Response: Expect().
 				Status(304),

--- a/tests/t0116_gateway_cache_test.go
+++ b/tests/t0116_gateway_cache_test.go
@@ -15,9 +15,8 @@ func TestGatewayCache(t *testing.T) {
 	// https://specs.ipfs.tech/http-gateways/path-gateway/#get-ipns-name-path-params
 	// var ipnsId string
 
-	// TODO: Add request chaining support to the test framework and enable the etag tests
 	// https://specs.ipfs.tech/http-gateways/path-gateway/#etag-response-header
-	// var etag string
+	var etag string
 
 	tests := SugarTests{
 		{
@@ -285,29 +284,46 @@ func TestGatewayCache(t *testing.T) {
 				Status(304),
 		},
 		*/
-		// The tests below require `etag` to be set.
-		/*
 		{
+			Name: "GET for /ipfs/ dir listing responds with Etag",
+			Request: Request().
+				Path("ipfs/%s/root2/root3/", fixture.MustGetCid()),
+			Response: Expect().
+				Status(200).
+				Headers(
+					Header("Etag").
+						Checks(func (v string) bool {
+							etag = v
+							return v != ""
+						}),
+				),
+		},
+		{
+			// DependsOn: "GET for /ipfs/ dir listing responds with Etag"
 			Name: "GET for /ipfs/ dir listing with matching strong Etag in If-None-Match returns 304 Not Modified",
 			Request: Request().
 				Path("ipfs/%s/root2/root3/", fixture.MustGetCid()).
 				Headers(
-					Header("If-None-Match", fmt.Sprintf("\"%s\"", etag)),
+					Header("If-None-Match").
+						ValueFrom(&etag),
 				),
 			Response: Expect().
 				Status(304),
 		},
 		{
+			// DependsOn: "GET for /ipfs/ dir listing responds with Etag"
 			Name: "GET for /ipfs/ dir listing with matching strong Etag in If-None-Match returns 304 Not Modified",
 			Request: Request().
 				Path("ipfs/%s/root2/root3/", fixture.MustGetCid()).
 				Headers(
-					Header("If-None-Match", fmt.Sprintf("W/\"%s\"", etag)),
+					Header("If-None-Match").
+						ValueFromFunc(func () string {
+							return fmt.Sprintf("W/%s", etag)
+						}),
 				),
 			Response: Expect().
 				Status(304),
 		},
-		*/
 	}
 
 	Run(t, tests)

--- a/tests/t0116_gateway_cache_test.go
+++ b/tests/t0116_gateway_cache_test.go
@@ -291,6 +291,8 @@ func TestGatewayCache(t *testing.T) {
 			Response: Expect().
 				Status(200).
 				Headers(
+					// TODO: We should make etag setting more explicit than a side-effect of the check.
+					// E.g. Header("Etag").ValueTo(&etag).Not().IsEmpty()
 					Header("Etag").
 						Checks(func(v string) bool {
 							etag = v
@@ -299,11 +301,14 @@ func TestGatewayCache(t *testing.T) {
 				),
 		},
 		{
+			// NOTE: Do we need a more formal way to express dependencies between test cases?
 			// DependsOn: "GET for /ipfs/ dir listing responds with Etag"
 			Name: "GET for /ipfs/ dir listing with matching strong Etag in If-None-Match returns 304 Not Modified",
 			Request: Request().
 				Path("ipfs/%s/root2/root3/", fixture.MustGetCid()).
 				Headers(
+					// TODO: Check that etag is set.
+					// E.g. Header("If-None-Match").ValueFrom(&etag).Not().IsEmpty()
 					Header("If-None-Match").
 						ValueFrom(&etag),
 				),

--- a/tests/t0117_gateway_block_test.go
+++ b/tests/t0117_gateway_block_test.go
@@ -117,7 +117,7 @@ func TestGatewayBlock(t *testing.T) {
 						}),
 				),
 		},
-	}.Build()
+	}
 
 	Run(t, tests)
 }

--- a/tests/t0118_gateway_car_test.go
+++ b/tests/t0118_gateway_car_test.go
@@ -43,7 +43,7 @@ func TestGatewayCar(t *testing.T) {
 						Equals("none"),
 				),
 		},
-	}.Build()
+	}
 
 	Run(t, tests)
 }

--- a/tests/t0122_gateway_tar_test.go
+++ b/tests/t0122_gateway_tar_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func TestGatewayTar(t *testing.T) {
-	tests := []test.CTest{}
+	tests := test.SugarTests{}
 
 	test.Run(t, tests)
 }

--- a/tests/t0123_gateway_json_cbor_test.go
+++ b/tests/t0123_gateway_json_cbor_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func TestGatewayJsonCbor(t *testing.T) {
-	tests := []test.CTest{}
+	tests := test.SugarTests{}
 
 	test.Run(t, tests)
 }

--- a/tests/t0400_api_no_gateway_test.go
+++ b/tests/t0400_api_no_gateway_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func TestApiNoGateway(t *testing.T) {
-	tests := []test.CTest{}
+	tests := test.SugarTests{}
 
 	test.Run(t, tests)
 }

--- a/tooling/test/config.go
+++ b/tooling/test/config.go
@@ -25,7 +25,6 @@ var SubdomainGatewayURL = strings.TrimRight(
 	GetEnv("SUBDOMAIN_GATEWAY_URL", "http://example.com"),
 	"/")
 
-
 var GatewayHost = ""
 var SubdomainGatewayHost = ""
 var SubdomainGatewayScheme = ""

--- a/tooling/test/provider.go
+++ b/tooling/test/provider.go
@@ -9,3 +9,9 @@ type StringProvider string
 func (p StringProvider) Get() string {
 	return string(p)
 }
+
+type FuncProvider[T any] func() T
+
+func (p FuncProvider[T]) Get() T {
+	return p()
+}

--- a/tooling/test/provider.go
+++ b/tooling/test/provider.go
@@ -1,0 +1,11 @@
+package test
+
+type Provider[T any] interface {
+	Get() T
+}
+
+type StringProvider string
+
+func (p StringProvider) Get() string {
+	return string(p)
+}

--- a/tooling/test/report.go
+++ b/tooling/test/report.go
@@ -9,7 +9,6 @@ import (
 	"text/template"
 )
 
-
 type ReportInput struct {
 	Req  *http.Request
 	Res  *http.Response
@@ -53,7 +52,7 @@ func report(t *testing.T, test CTest, req *http.Request, res *http.Response, err
 			if v == nil {
 				return "nil"
 			}
-			
+
 			var b []byte
 			var err error
 			switch v := v.(type) {
@@ -71,7 +70,7 @@ func report(t *testing.T, test CTest, req *http.Request, res *http.Response, err
 			if err != nil {
 				panic(err)
 			}
-			
+
 			return string(b)
 		},
 	}).Parse(TEMPLATE)

--- a/tooling/test/report.go
+++ b/tooling/test/report.go
@@ -23,10 +23,10 @@ Hint: {{.Test.Hint}}
 Error: {{.Err}}
 
 Request:
-{{.Test.Request.Request() | json}}
+{{.Test.Request | json}}
 
 Expected Response:
-{{.Test.Response.Response() | json}}
+{{.Test.Response | json}}
 
 Actual Request:
 {{.Req | dump}}

--- a/tooling/test/report.go
+++ b/tooling/test/report.go
@@ -13,7 +13,7 @@ type ReportInput struct {
 	Req  *http.Request
 	Res  *http.Response
 	Err  error
-	Test CTest
+	Test SugarTest
 }
 
 const TEMPLATE = `
@@ -23,10 +23,10 @@ Hint: {{.Test.Hint}}
 Error: {{.Err}}
 
 Request:
-{{.Test.Request | json}}
+{{.Test.Request.Request() | json}}
 
 Expected Response:
-{{.Test.Response | json}}
+{{.Test.Response.Response() | json}}
 
 Actual Request:
 {{.Req | dump}}
@@ -35,7 +35,7 @@ Actual Response:
 {{.Res | dump}}
 `
 
-func report(t *testing.T, test CTest, req *http.Request, res *http.Response, err error) {
+func report(t *testing.T, test SugarTest, req *http.Request, res *http.Response, err error) {
 	input := ReportInput{
 		Req:  req,
 		Res:  res,

--- a/tooling/test/sugar.go
+++ b/tooling/test/sugar.go
@@ -182,6 +182,11 @@ func (h HeaderBuilder) ValueFrom(value *string) HeaderBuilder {
 	return h
 }
 
+func (h HeaderBuilder) ValueFromFunc(value func() string) HeaderBuilder {
+	h.Value_ = FuncProvider[string](value)
+	return h
+}
+
 func (h HeaderBuilder) Contains(value string, rest ...any) HeaderBuilder {
 	h.Check_ = check.Contains(value, rest...)
 	return h

--- a/tooling/test/sugar.go
+++ b/tooling/test/sugar.go
@@ -172,6 +172,18 @@ func Header(key string, opts ...string) HeaderBuilder {
 	return HeaderBuilder{Key_: key}
 }
 
+func (h HeaderBuilder) Value(value string, args ...any) HeaderBuilder {
+	h.Value_ = StringProvider(fmt.Sprintf(value, args...))
+	return h
+}
+
+func (h HeaderBuilder) ValueFrom(value *string) HeaderBuilder {
+	h.Value_ = FuncProvider[string](func() string {
+		return *value
+	})
+	return h
+}
+
 func (h HeaderBuilder) Contains(value string, rest ...any) HeaderBuilder {
 	h.Check_ = check.Contains(value, rest...)
 	return h

--- a/tooling/test/sugar.go
+++ b/tooling/test/sugar.go
@@ -8,15 +8,15 @@ import (
 )
 
 type RequestBuilder struct {
-	Method_               string            `json:"method,omitempty"`
-	Path_                 string            `json:"path,omitempty"`
-	URL_                  string            `json:"url,omitempty"`
-	Proxy_                string            `json:"proxy,omitempty"`
-	UseProxyTunnel_       bool              `json:"useProxyTunnel,omitempty"`
-	Headers_              map[string]string `json:"headers,omitempty"`
-	DoNotFollowRedirects_ bool              `json:"doNotFollowRedirects,omitempty"`
-	Query_                url.Values        `json:"query,omitempty"`
-	Body_                 []byte            `json:"body,omitempty"`
+	Method_               string                      `json:"method,omitempty"`
+	Path_                 string                      `json:"path,omitempty"`
+	URL_                  string                      `json:"url,omitempty"`
+	Proxy_                string                      `json:"proxy,omitempty"`
+	UseProxyTunnel_       bool                        `json:"useProxyTunnel,omitempty"`
+	Headers_              map[string]Provider[string] `json:"headers,omitempty"`
+	DoNotFollowRedirects_ bool                        `json:"doNotFollowRedirects,omitempty"`
+	Query_                url.Values                  `json:"query,omitempty"`
+	Body_                 []byte                      `json:"body,omitempty"`
 }
 
 func Request() RequestBuilder {
@@ -69,22 +69,21 @@ func (r RequestBuilder) Method(method string) RequestBuilder {
 
 func (r RequestBuilder) Header(k, v string) RequestBuilder {
 	if r.Headers_ == nil {
-		r.Headers_ = make(map[string]string)
+		r.Headers_ = make(map[string]Provider[string])
 	}
 
-	r.Headers_[k] = v
+	r.Headers_[k] = StringProvider(v)
 	return r
 }
 
 func (r RequestBuilder) Headers(hs ...HeaderBuilder) RequestBuilder {
 	if r.Headers_ == nil {
-		r.Headers_ = make(map[string]string)
+		r.Headers_ = make(map[string]Provider[string])
 	}
 
 	for _, h := range hs {
 		r.Headers_[h.Key_] = h.Value_
 	}
-
 	return r
 }
 
@@ -157,7 +156,7 @@ func (e ExpectBuilder) BodyWithHint(hint string, body interface{}) ExpectBuilder
 
 type HeaderBuilder struct {
 	Key_   string              `json:"key,omitempty"`
-	Value_ string              `json:"value,omitempty"`
+	Value_ Provider[string]    `json:"value,omitempty"`
 	Check_ check.Check[string] `json:"-"`
 	Hint_  string              `json:"-"`
 }
@@ -167,7 +166,7 @@ func Header(key string, opts ...string) HeaderBuilder {
 		panic("too many options")
 	}
 	if len(opts) > 0 {
-		return HeaderBuilder{Key_: key, Value_: opts[0], Check_: check.IsEqual(opts[0])}
+		return HeaderBuilder{Key_: key, Value_: StringProvider(opts[0]), Check_: check.IsEqual(opts[0])}
 	}
 
 	return HeaderBuilder{Key_: key}

--- a/tooling/test/sugar.go
+++ b/tooling/test/sugar.go
@@ -8,15 +8,15 @@ import (
 )
 
 type RequestBuilder struct {
-	Method_               string                      `json:"method,omitempty"`
-	Path_                 string                      `json:"path,omitempty"`
-	URL_                  string                      `json:"url,omitempty"`
-	Proxy_                string                      `json:"proxy,omitempty"`
-	UseProxyTunnel_       bool                        `json:"useProxyTunnel,omitempty"`
-	Headers_              map[string]Provider[string] `json:"headers,omitempty"`
-	DoNotFollowRedirects_ bool                        `json:"doNotFollowRedirects,omitempty"`
-	Query_                url.Values                  `json:"query,omitempty"`
-	Body_                 []byte                      `json:"body,omitempty"`
+	Method_               string          `json:"method,omitempty"`
+	Path_                 string          `json:"path,omitempty"`
+	URL_                  string          `json:"url,omitempty"`
+	Proxy_                string          `json:"proxy,omitempty"`
+	UseProxyTunnel_       bool            `json:"useProxyTunnel,omitempty"`
+	Headers_              []HeaderBuilder `json:"headers,omitempty"`
+	DoNotFollowRedirects_ bool            `json:"doNotFollowRedirects,omitempty"`
+	Query_                url.Values      `json:"query,omitempty"`
+	Body_                 []byte          `json:"body,omitempty"`
 }
 
 func Request() RequestBuilder {
@@ -69,21 +69,19 @@ func (r RequestBuilder) Method(method string) RequestBuilder {
 
 func (r RequestBuilder) Header(k, v string) RequestBuilder {
 	if r.Headers_ == nil {
-		r.Headers_ = make(map[string]Provider[string])
+		r.Headers_ = make([]HeaderBuilder, 0)
 	}
 
-	r.Headers_[k] = StringProvider(v)
+	r.Headers_ = append(r.Headers_, Header(k, v))
 	return r
 }
 
 func (r RequestBuilder) Headers(hs ...HeaderBuilder) RequestBuilder {
 	if r.Headers_ == nil {
-		r.Headers_ = make(map[string]Provider[string])
+		r.Headers_ = make([]HeaderBuilder, 0)
 	}
 
-	for _, h := range hs {
-		r.Headers_[h.Key_] = h.Value_
-	}
+	r.Headers_ = append(r.Headers_, hs...)
 	return r
 }
 

--- a/tooling/test/sugar.go
+++ b/tooling/test/sugar.go
@@ -152,6 +152,7 @@ func (e ExpectBuilder) BodyWithHint(hint string, body interface{}) ExpectBuilder
 	return e
 }
 
+// TODO: split into two types: RequestHeaderBuidler and ResponseHeaderBuilder
 type HeaderBuilder struct {
 	Key_   string              `json:"key,omitempty"`
 	Value_ Provider[string]    `json:"value,omitempty"`

--- a/tooling/test/test.go
+++ b/tooling/test/test.go
@@ -30,13 +30,6 @@ type CResponse struct {
 	Body       interface{}            `json:"body,omitempty"`
 }
 
-type CTest struct {
-	Name     string    `json:"name,omitempty"`
-	Hint     string    `json:"hint,omitempty"`
-	Request  CRequest  `json:"request,omitempty"`
-	Response CResponse `json:"response,omitempty"`
-}
-
 type SugarTest struct {
 	Name     string
 	Hint     string
@@ -46,25 +39,15 @@ type SugarTest struct {
 
 type SugarTests []SugarTest
 
-func (s SugarTests) Build() []CTest {
-	var tests []CTest
-	for _, test := range s {
-		tests = append(tests, CTest{
-			Name:     test.Name,
-			Hint:     test.Hint,
-			Request:  test.Request.Request(),
-			Response: test.Response.Response(),
-		})
-	}
-	return tests
-}
-
 func Run(t *testing.T, tests SugarTests) {
 	// NewDialer()
 
-	for _, test := range tests.Build() {
+	for _, test := range tests {
 		t.Run(test.Name, func(t *testing.T) {
-			method := test.Request.Method
+			request := test.Request.Request()
+			response := test.Response.Response()
+
+			method := request.Method
 			if method == "" {
 				method = "GET"
 			}
@@ -72,17 +55,17 @@ func Run(t *testing.T, tests SugarTests) {
 			// Prepare a client,
 			// use proxy, deal with redirects, etc.
 			client := &http.Client{}
-			if test.Request.UseProxyTunnel {
-				if test.Request.Proxy == "" {
+			if request.UseProxyTunnel {
+				if request.Proxy == "" {
 					t.Fatal("ProxyTunnel requires a proxy")
 				}
 
-				client = NewProxyTunnelClient(test.Request.Proxy)
-			} else if test.Request.Proxy != "" {
-				client = NewProxyClient(test.Request.Proxy)
+				client = NewProxyTunnelClient(request.Proxy)
+			} else if request.Proxy != "" {
+				client = NewProxyClient(request.Proxy)
 			}
 
-			if test.Request.DoNotFollowRedirects {
+			if request.DoNotFollowRedirects {
 				client.CheckRedirect = func(req *http.Request, via []*http.Request) error {
 					return http.ErrUseLastResponse
 				}
@@ -106,27 +89,27 @@ func Run(t *testing.T, tests SugarTests) {
 			}
 
 			var url string
-			if test.Request.URL != "" && test.Request.Path != "" {
+			if request.URL != "" && request.Path != "" {
 				localReport(t, "Both 'URL' and 'Path' are set")
 			}
-			if test.Request.URL == "" && test.Request.Path == "" {
+			if request.URL == "" && request.Path == "" {
 				localReport(t, "Neither 'URL' nor 'Path' are set")
 			}
-			if test.Request.URL != "" {
-				url = test.Request.URL
+			if request.URL != "" {
+				url = request.URL
 			}
-			if test.Request.Path != "" {
-				url = fmt.Sprintf("%s/%s", GatewayURL, test.Request.Path)
+			if request.Path != "" {
+				url = fmt.Sprintf("%s/%s", GatewayURL, request.Path)
 			}
 
-			query := test.Request.Query.Encode()
+			query := request.Query.Encode()
 			if query != "" {
 				url = fmt.Sprintf("%s?%s", url, query)
 			}
 
 			var body io.Reader
-			if test.Request.Body != nil {
-				body = bytes.NewBuffer(test.Request.Body)
+			if request.Body != nil {
+				body = bytes.NewBuffer(request.Body)
 			}
 
 			// create a request
@@ -136,7 +119,7 @@ func Run(t *testing.T, tests SugarTests) {
 			}
 
 			// add headers
-			for key, value := range test.Request.Headers {
+			for key, value := range request.Headers {
 				req.Header.Add(key, value)
 
 				// https://github.com/golang/go/issues/7682
@@ -152,13 +135,13 @@ func Run(t *testing.T, tests SugarTests) {
 				localReport(t, "Querying %s failed: %s", url, err)
 			}
 
-			if test.Response.StatusCode != 0 {
-				if res.StatusCode != test.Response.StatusCode {
-					localReport(t, "Status code is not %d. It is %d", test.Response.StatusCode, res.StatusCode)
+			if response.StatusCode != 0 {
+				if res.StatusCode != response.StatusCode {
+					localReport(t, "Status code is not %d. It is %d", response.StatusCode, res.StatusCode)
 				}
 			}
 
-			for key, value := range test.Response.Headers {
+			for key, value := range response.Headers {
 				t.Run(fmt.Sprintf("Header %s", key), func(t *testing.T) {
 					actual := res.Header.Get(key)
 
@@ -187,14 +170,14 @@ func Run(t *testing.T, tests SugarTests) {
 				})
 			}
 
-			if test.Response.Body != nil {
+			if response.Body != nil {
 				defer res.Body.Close()
 				resBody, err := io.ReadAll(res.Body)
 				if err != nil {
 					localReport(t, err)
 				}
 
-				switch v := test.Response.Body.(type) {
+				switch v := response.Body.(type) {
 				case check.Check[string]:
 					output := v.Check(string(resBody))
 					if !output.Success {
@@ -212,13 +195,13 @@ func Run(t *testing.T, tests SugarTests) {
 				case []byte:
 					if !bytes.Equal(resBody, v) {
 						if res.Header.Get("Content-Type") == "application/vnd.ipld.raw" {
-							localReport(t, "Body is not '%+v'. It is: '%+v'", test.Response.Body, resBody)
+							localReport(t, "Body is not '%+v'. It is: '%+v'", response.Body, resBody)
 						} else {
-							localReport(t, "Body is not '%s'. It is: '%s'", test.Response.Body, resBody)
+							localReport(t, "Body is not '%s'. It is: '%s'", response.Body, resBody)
 						}
 					}
 				default:
-					localReport(t, "Body check has an invalid type: %T", test.Response.Body)
+					localReport(t, "Body check has an invalid type: %T", response.Body)
 				}
 			}
 		})

--- a/tooling/test/test.go
+++ b/tooling/test/test.go
@@ -100,11 +100,11 @@ func Run(t *testing.T, tests SugarTests) {
 
 			// add headers
 			for key, value := range request.Headers_ {
-				req.Header.Add(key, value)
+				req.Header.Add(key, value.Get())
 
 				// https://github.com/golang/go/issues/7682
 				if key == "Host" {
-					req.Host = value
+					req.Host = value.Get()
 				}
 			}
 

--- a/tooling/test/test.go
+++ b/tooling/test/test.go
@@ -99,12 +99,14 @@ func Run(t *testing.T, tests SugarTests) {
 			}
 
 			// add headers
-			for key, value := range request.Headers_ {
-				req.Header.Add(key, value.Get())
+			for _, header := range request.Headers_ {
+				key := header.Key_
+				value := header.Value_.Get()
+				req.Header.Add(key, value)
 
 				// https://github.com/golang/go/issues/7682
 				if key == "Host" {
-					req.Host = value.Get()
+					req.Host = value
 				}
 			}
 

--- a/tooling/test/test.go
+++ b/tooling/test/test.go
@@ -59,10 +59,10 @@ func (s SugarTests) Build() []CTest {
 	return tests
 }
 
-func Run(t *testing.T, tests []CTest) {
+func Run(t *testing.T, tests SugarTests) {
 	// NewDialer()
 
-	for _, test := range tests {
+	for _, test := range tests.Build() {
 		t.Run(test.Name, func(t *testing.T) {
 			method := test.Request.Method
 			if method == "" {


### PR DESCRIPTION
This PR ends up doing a bit more than I intended at first. It:
- rewrites t0116 in sugar mode - https://github.com/ipfs/gateway-conformance/pull/30/commits/1cf17297ef19ff7fac17ffc935fa5c428ac80d71
- makes `SugarTests` the default for defining tests - https://github.com/ipfs/gateway-conformance/pull/30/commits/5dde1751f204c2c4c2f2847851f3c3bc8806c9c1
- makes `SugarTests` the only option for defining tests - https://github.com/ipfs/gateway-conformance/pull/30/commits/72453bcd1a761f40530c2e6c831d08c25a321f63 and https://github.com/ipfs/gateway-conformance/pull/30/commits/cdddcc91fd555002a125613f618d9f927d825b22
- adds `Provider` interface (think `StringProvider(value).Get() rather than using value directly) - https://github.com/ipfs/gateway-conformance/pull/30/commits/284e1e62efa5f4253586dade6790f3b5a645ccb3
- adds a way to init header value from a variable - https://github.com/ipfs/gateway-conformance/pull/30/commits/8e967b3ae094f03b3ade0dad5271195f396d1493
- adds a way to init header value with a function - https://github.com/ipfs/gateway-conformance/pull/30/commits/f5cace99713711d0ffb5114c7e6b07066951f014
- enables t0116 test cases that depend on responses from other test cases - https://github.com/ipfs/gateway-conformance/pull/30/commits/4e7e0486addcb1ed1c59b034d4f0fdae7816eebe
- adds comments on next steps - https://github.com/ipfs/gateway-conformance/pull/30/commits/2f9adafacfedf8749a7f6e8e0b5675854f165e50

I mentioned some of the interesting commits up here. I think looking at it that way is much more convenient. We can definitely discuss this in person too!

Feedback is more than welcome. 

I think embracing SugarTests would let us simplify quite a bit of the internals. 

The way I implemented information sharing between requests... I'm not 100% convinced. 
- It works cause' test cases are executed sequentially, which is always true for sub-test cases. 
- If we were to exclude the dependency test case or run only the test that has dependencies, it'd fail. It might be fine because those are power user options anyway. 
- If the dependency test case failed, the dependee would fail too, but the error wouldn't indicate the reason too well. Maybe it's enough to check the request before making it and add some hints around it.

Other things for consideration:
- We could group tests with dependencies more formally so that if the dependency fails, we don't even execute the latter test cases.
- The request from the dependency could be done outside test cases. The downside is, any failure would hold back all the test cases.

Finally, important to note that this PR doesn't enable IPNS test cases.