### PR TITLE
chore: ensure t0116 test implements all the test cases sharness does

### DIFF
--- a/tests/t0116_gateway_cache_test.go
+++ b/tests/t0116_gateway_cache_test.go
@@ -8,12 +8,16 @@ import (
 	. "github.com/ipfs/gateway-conformance/tooling/test"
 )
 
-/* These tests do not cover the following:
-** - /ipns/ paths
-** - "If-None-Match" header handling for strong ETags for dir listings (the ones with xxhash)
- */
 func TestGatewayCache(t *testing.T) {
 	fixture := car.MustOpenUnixfsCar("t0116-gateway-cache.car")
+
+	// TODO: Add ipns record support to fixtures and enable the ipns tests
+	// https://specs.ipfs.tech/http-gateways/path-gateway/#get-ipns-name-path-params
+	// var ipnsId string
+
+	// TODO: Add request chaining support to the test framework and enable the etag tests
+	// https://specs.ipfs.tech/http-gateways/path-gateway/#etag-response-header
+	// var etag string
 
 	tests := SugarTests{
 		{
@@ -191,6 +195,117 @@ func TestGatewayCache(t *testing.T) {
 			Response: Expect().
 				Status(304),
 		},
+		// The tests below require `ipnsId` to be set.
+		/*
+		{
+			Name: "GET for /ipns/ unixfs dir listing succeeds",
+			Request: Request().
+				Path("ipns/%s/root2/root3/", ipnsId),
+			Response: Expect().
+				Status(200).
+				Headers(
+					Header("Cache-Control").
+						IsEmpty(),
+					Header("X-Ipfs-Path").
+						Equals("/ipns/%s/root2/root3", ipnsId),
+					Header("X-Ipfs-Roots").
+						Equals("%s,%s,%s", fixture.MustGetCid(), fixture.MustGetCid("root2"), fixture.MustGetCid("root2", "root3")),
+					Header("Etag").
+						Matches("DirIndex-.*_CID-%s", fixture.MustGetCid("root2", "root3")),
+				),
+		},
+		{
+			Name: "GET for /ipns/ unixfs dir with index.html succeeds",
+			Request: Request().
+				Path("ipns/%s/root2/root3/root4/", ipnsId),
+			Response: Expect().
+				Status(200).
+				Headers(
+					Header("Cache-Control").
+						IsEmpty(),
+					Header("X-Ipfs-Path").
+						Equals("/ipns/%s/root2/root3/root4/", ipnsId),
+					Header("X-Ipfs-Roots").
+						Equals("%s,%s,%s,%s", fixture.MustGetCid(), fixture.MustGetCid("root2"), fixture.MustGetCid("root2", "root3"), fixture.MustGetCid("root2", "root3", "root4")),
+					Header("Etag").
+						Matches("DirIndex-.*_CID-%s", fixture.MustGetCid("root2", "root3", "root4")),
+				),
+		},
+		{
+			Name: "GET for /ipns/ unixfs file succeeds",
+			Request: Request().
+				Path("ipns/%s/root2/root3/root4/index.html", ipnsId),
+			Response: Expect().
+				Status(200).
+				Headers(
+					Header("Cache-Control").
+						Equals("public, max-age=29030400, immutable"),
+					Header("X-Ipfs-Path").
+						Equals("/ipns/%s/root2/root3/root4/index.html", ipnsId),
+					Header("X-Ipfs-Roots").
+						Equals("%s,%s,%s,%s,%s", fixture.MustGetCid(), fixture.MustGetCid("root2"), fixture.MustGetCid("root2", "root3"), fixture.MustGetCid("root2", "root3", "root4"), fixture.MustGetCid("root2", "root3", "root4", "index.html")),
+					Header("Etag").
+						Equals("\"%s\"", fixture.MustGetCid("root2", "root3", "root4", "index.html")),
+				),
+		},
+		{
+			Name: "GET for /ipns/ unixfs dir as DAG-JSON succeeds",
+			Request: Request().
+				Path("ipns/%s/root2/root3/root4/", ipnsId).
+				Query("format", "dag-json"),
+			Response: Expect().
+				Status(200).
+				Headers(
+					Header("Cache-Control").
+						Equals("public, max-age=29030400, immutable"),
+				),
+		},
+		{
+			Name: "GET for /ipns/ unixfs dir as JSON succeeds",
+			Request: Request().
+				Path("ipns/%s/root2/root3/root4/", ipnsId).
+				Query("format", "json"),
+			Response: Expect().
+				Status(200).
+				Headers(
+					Header("Cache-Control").
+						Equals("public, max-age=29030400, immutable"),
+				),
+		},
+		{
+			Name: "GET for /ipns/ file with matching Etag in If-None-Match returns 304 Not Modified",
+			Request: Request().
+				Path("ipns/%s/root2/root3/root4/index.html", ipnsId).
+				Headers(
+					Header("If-None-Match", fmt.Sprintf("\"%s\"", fixture.MustGetCid("root2", "root3", "root4", "index.html"))),
+				),
+			Response: Expect().
+				Status(304),
+		},
+		*/
+		// The tests below require `etag` to be set.
+		/*
+		{
+			Name: "GET for /ipfs/ dir listing with matching strong Etag in If-None-Match returns 304 Not Modified",
+			Request: Request().
+				Path("ipfs/%s/root2/root3/", fixture.MustGetCid()).
+				Headers(
+					Header("If-None-Match", fmt.Sprintf("\"%s\"", etag)),
+				),
+			Response: Expect().
+				Status(304),
+		},
+		{
+			Name: "GET for /ipfs/ dir listing with matching strong Etag in If-None-Match returns 304 Not Modified",
+			Request: Request().
+				Path("ipfs/%s/root2/root3/", fixture.MustGetCid()).
+				Headers(
+					Header("If-None-Match", fmt.Sprintf("W/\"%s\"", etag)),
+				),
+			Response: Expect().
+				Status(304),
+		},
+		*/
 	}.Build()
 
 	Run(t, tests)

--- a/tests/t0116_gateway_cache_test.go
+++ b/tests/t0116_gateway_cache_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 
 	"github.com/ipfs/gateway-conformance/tooling/car"
-	. "github.com/ipfs/gateway-conformance/tooling/check"
 	. "github.com/ipfs/gateway-conformance/tooling/test"
 )
 
@@ -16,197 +15,183 @@ import (
 func TestGatewayCache(t *testing.T) {
 	fixture := car.MustOpenUnixfsCar("t0116-gateway-cache.car")
 
-	tests := []CTest{
+	tests := SugarTests{
 		{
 			Name: "GET for /ipfs/ unixfs dir listing succeeds",
-			Request: CRequest{
-				Path: fmt.Sprintf("ipfs/%s/root2/root3/", fixture.MustGetCid()),
-			},
-			Response: CResponse{
-				StatusCode: 200,
-				Headers: map[string]interface{}{
-					"Cache-Control": IsEmpty(),
-					"X-Ipfs-Path":   IsEqual("/ipfs/%s/root2/root3/", fixture.MustGetCid()),
-					"X-Ipfs-Roots":  IsEqual("%s,%s,%s", fixture.MustGetCid(), fixture.MustGetCid("root2"), fixture.MustGetCid("root2", "root3")),
-					"Etag":          Matches("DirIndex-.*_CID-%s", fixture.MustGetCid("root2", "root3")),
-				},
-			},
+			Request: Request().
+				Path("ipfs/%s/root2/root3/", fixture.MustGetCid()),
+			Response: Expect().
+				Status(200).
+				Headers(
+					Header("Cache-Control").
+						IsEmpty(),
+					Header("X-Ipfs-Path").
+						Equals("/ipfs/%s/root2/root3/", fixture.MustGetCid()),
+					Header("X-Ipfs-Roots").
+						Equals("%s,%s,%s", fixture.MustGetCid(), fixture.MustGetCid("root2"), fixture.MustGetCid("root2", "root3")),
+					Header("Etag").
+						Matches("DirIndex-.*_CID-%s", fixture.MustGetCid("root2", "root3")),
+				),
 		},
 		{
 			Name: "GET for /ipfs/ unixfs dir with index.html succeeds",
-			Request: CRequest{
-				Path: fmt.Sprintf("ipfs/%s/root2/root3/root4/", fixture.MustGetCid()),
-			},
-			Response: CResponse{
-				StatusCode: 200,
-				Headers: map[string]interface{}{
-					"Cache-Control": "public, max-age=29030400, immutable",
-					"X-Ipfs-Path":   IsEqual("/ipfs/%s/root2/root3/root4/", fixture.MustGetCid()),
-					"X-Ipfs-Roots":  IsEqual("%s,%s,%s,%s", fixture.MustGetCid(), fixture.MustGetCid("root2"), fixture.MustGetCid("root2", "root3"), fixture.MustGetCid("root2", "root3", "root4")),
-					"Etag":          IsEqual("\"%s\"", fixture.MustGetCid("root2", "root3", "root4")),
-				},
-			},
+			Request: Request().
+				Path("ipfs/%s/root2/root3/root4/", fixture.MustGetCid()),
+			Response: Expect().
+				Status(200).
+				Headers(
+					Header("Cache-Control").
+						Equals("public, max-age=29030400, immutable"),
+					Header("X-Ipfs-Path").
+						Equals("/ipfs/%s/root2/root3/root4/", fixture.MustGetCid()),
+					Header("X-Ipfs-Roots").
+						Equals("%s,%s,%s,%s", fixture.MustGetCid(), fixture.MustGetCid("root2"), fixture.MustGetCid("root2", "root3"), fixture.MustGetCid("root2", "root3", "root4")),
+					Header("Etag").
+						Equals("\"%s\"", fixture.MustGetCid("root2", "root3", "root4")),
+				),
 		},
 		{
 			Name: "GET for /ipfs/ unixfs file succeeds",
-			Request: CRequest{
-				Path: fmt.Sprintf("ipfs/%s/root2/root3/root4/index.html", fixture.MustGetCid()),
-			},
-			Response: CResponse{
-				StatusCode: 200,
-				Headers: map[string]interface{}{
-					"Cache-Control": "public, max-age=29030400, immutable",
-					"X-Ipfs-Path":   IsEqual("/ipfs/%s/root2/root3/root4/index.html", fixture.MustGetCid()),
-					"X-Ipfs-Roots":  IsEqual("%s,%s,%s,%s,%s", fixture.MustGetCid(), fixture.MustGetCid("root2"), fixture.MustGetCid("root2", "root3"), fixture.MustGetCid("root2", "root3", "root4"), fixture.MustGetCid("root2", "root3", "root4", "index.html")),
-					"Etag":          IsEqual("\"%s\"", fixture.MustGetCid("root2", "root3", "root4", "index.html")),
-				},
-			},
+			Request: Request().
+				Path("ipfs/%s/root2/root3/root4/index.html", fixture.MustGetCid()),
+			Response: Expect().
+				Status(200).
+				Headers(
+					Header("Cache-Control").
+						Equals("public, max-age=29030400, immutable"),
+					Header("X-Ipfs-Path").
+						Equals("/ipfs/%s/root2/root3/root4/index.html", fixture.MustGetCid()),
+					Header("X-Ipfs-Roots").
+						Equals("%s,%s,%s,%s,%s", fixture.MustGetCid(), fixture.MustGetCid("root2"), fixture.MustGetCid("root2", "root3"), fixture.MustGetCid("root2", "root3", "root4"), fixture.MustGetCid("root2", "root3", "root4", "index.html")),
+					Header("Etag").
+						Equals("\"%s\"", fixture.MustGetCid("root2", "root3", "root4", "index.html")),
+				),
 		},
 		{
 			Name: "GET for /ipfs/ unixfs dir as DAG-JSON succeeds",
-			Request: CRequest{
-				Path: fmt.Sprintf("ipfs/%s/root2/root3/root4/?format=dag-json", fixture.MustGetCid()),
-			},
-			Response: CResponse{
-				StatusCode: 200,
-				Headers: map[string]interface{}{
-					"Cache-Control": "public, max-age=29030400, immutable",
-				},
-			},
+			Request: Request().
+				Path("ipfs/%s/root2/root3/root4/?format=dag-json", fixture.MustGetCid()),
+			Response: Expect().
+				Status(200).
+				Headers(
+					Header("Cache-Control").
+						Equals("public, max-age=29030400, immutable"),
+				),
 		},
 		{
 			Name: "GET for /ipfs/ unixfs dir as JSON succeeds",
-			Request: CRequest{
-				Path: fmt.Sprintf("ipfs/%s/root2/root3/root4/?format=json", fixture.MustGetCid()),
-			},
-			Response: CResponse{
-				StatusCode: 200,
-				Headers: map[string]interface{}{
-					"Cache-Control": "public, max-age=29030400, immutable",
-				},
-			},
+			Request: Request().
+				Path("ipfs/%s/root2/root3/root4/?format=json", fixture.MustGetCid()),
+			Response: Expect().
+				Status(200).
+				Headers(
+					Header("Cache-Control").
+						Equals("public, max-age=29030400, immutable"),
+				),
 		},
 		{
 			Name: "HEAD for /ipfs/ with only-if-cached succeeds when in local datastore",
-			Request: CRequest{
-				Path: fmt.Sprintf("ipfs/%s/root2/root3/root4/?format=json", fixture.MustGetCid()),
-				Headers: map[string]string{
-					"Cache-Control": "only-if-cached",
-				},
-				Method: "HEAD",
-			},
-			Response: CResponse{
-				StatusCode: 200,
-			},
+			Request: Request().
+				Path("ipfs/%s/root2/root3/root4/?format=json", fixture.MustGetCid()).
+				Headers(
+					Header("Cache-Control", "only-if-cached"),
+				).
+				Method("HEAD"),
+			Response: Expect().
+				Status(200),
 		},
 		{
 			Name: "HEAD for /ipfs/ with only-if-cached fails when not in local datastore",
-			Request: CRequest{
-				Path: "ipfs/QmYzfKSE55XCjD1MW128RfciAf2DViABhEiXfgVFMabSjN",
-				Headers: map[string]string{
-					"Cache-Control": "only-if-cached",
-				},
-				Method: "HEAD",
-			},
-			Response: CResponse{
-				StatusCode: 412,
-			},
+			Request: Request().
+				Path("ipfs/QmYzfKSE55XCjD1MW128RfciAf2DViABhEiXfgVFMabSjN").
+				Headers(
+					Header("Cache-Control", "only-if-cached"),
+				).
+				Method("HEAD"),
+			Response: Expect().
+				Status(412),
 		},
 		{
 			Name: "GET for /ipfs/ with only-if-cached succeeds when in local datastore",
-			Request: CRequest{
-				Path: fmt.Sprintf("ipfs/%s/root2/root3/root4/?format=json", fixture.MustGetCid()),
-				Headers: map[string]string{
-					"Cache-Control": "only-if-cached",
-				},
-			},
-			Response: CResponse{
-				StatusCode: 200,
-			},
+			Request: Request().
+				Path("ipfs/%s/root2/root3/root4/?format=json", fixture.MustGetCid()).
+				Headers(
+					Header("Cache-Control", "only-if-cached"),
+				),
+			Response: Expect().
+				Status(200),
 		},
 		{
 			Name: "GET for /ipfs/ with only-if-cached fails when not in local datastore",
-			Request: CRequest{
-				Path: "ipfs/QmYzfKSE55XCjD1MW128RfciAf2DViABhEiXfgVFMabSjN",
-				Headers: map[string]string{
-					"Cache-Control": "only-if-cached",
-				},
-			},
-			Response: CResponse{
-				StatusCode: 412,
-			},
+			Request: Request().
+				Path("ipfs/QmYzfKSE55XCjD1MW128RfciAf2DViABhEiXfgVFMabSjN").
+				Headers(
+					Header("Cache-Control", "only-if-cached"),
+				),
+			Response: Expect().
+				Status(412),
 		},
 		{
 			Name: "GET for /ipfs/ file with matching Etag in If-None-Match returns 304 Not Modified",
-			Request: CRequest{
-				Path: fmt.Sprintf("ipfs/%s/root2/root3/root4/index.html", fixture.MustGetCid()),
-				Headers: map[string]string{
-					"If-None-Match": fmt.Sprintf("\"%s\"", fixture.MustGetCid("root2", "root3", "root4", "index.html")),
-				},
-			},
-			Response: CResponse{
-				StatusCode: 304,
-			},
+			Request: Request().
+				Path("ipfs/%s/root2/root3/root4/index.html", fixture.MustGetCid()).
+				Headers(
+					Header("If-None-Match", fmt.Sprintf("\"%s\"", fixture.MustGetCid("root2", "root3", "root4", "index.html"))),
+				),
+			Response: Expect().
+				Status(304),
 		},
 		{
 			Name: "GET for /ipfs/ dir with index.html file with matching Etag in If-None-Match returns 304 Not Modified",
-			Request: CRequest{
-				Path: fmt.Sprintf("ipfs/%s/root2/root3/root4/", fixture.MustGetCid()),
-				Headers: map[string]string{
-					"If-None-Match": fmt.Sprintf("\"%s\"", fixture.MustGetCid("root2", "root3", "root4")),
-				},
-			},
-			Response: CResponse{
-				StatusCode: 304,
-			},
+			Request: Request().
+				Path("ipfs/%s/root2/root3/root4/", fixture.MustGetCid()).
+				Headers(
+					Header("If-None-Match", fmt.Sprintf("\"%s\"", fixture.MustGetCid("root2", "root3", "root4"))),
+				),
+			Response: Expect().
+				Status(304),
 		},
 		{
 			Name: "GET for /ipfs/ file with matching third Etag in If-None-Match returns 304 Not Modified",
-			Request: CRequest{
-				Path: fmt.Sprintf("ipfs/%s/root2/root3/root4/index.html", fixture.MustGetCid()),
-				Headers: map[string]string{
-					"If-None-Match": fmt.Sprintf("\"fakeEtag1\", \"fakeEtag2\", \"%s\"", fixture.MustGetCid("root2", "root3", "root4", "index.html")),
-				},
-			},
-			Response: CResponse{
-				StatusCode: 304,
-			},
+			Request: Request().
+				Path("ipfs/%s/root2/root3/root4/index.html", fixture.MustGetCid()).
+				Headers(
+					Header("If-None-Match", fmt.Sprintf("\"fakeEtag1\", \"fakeEtag2\", \"%s\"", fixture.MustGetCid("root2", "root3", "root4", "index.html"))),
+				),
+			Response: Expect().
+				Status(304),
 		},
 		{
 			Name: "GET for /ipfs/ file with matching weak Etag in If-None-Match returns 304 Not Modified",
-			Request: CRequest{
-				Path: fmt.Sprintf("ipfs/%s/root2/root3/root4/index.html", fixture.MustGetCid()),
-				Headers: map[string]string{
-					"If-None-Match": fmt.Sprintf("W/\"%s\"", fixture.MustGetCid("root2", "root3", "root4", "index.html")),
-				},
-			},
-			Response: CResponse{
-				StatusCode: 304,
-			},
-		}, {
-			Name: "GET for /ipfs/ file with wildcard Etag in If-None-Match returns 304 Not Modified",
-			Request: CRequest{
-				Path: fmt.Sprintf("ipfs/%s/root2/root3/root4/index.html", fixture.MustGetCid()),
-				Headers: map[string]string{
-					"If-None-Match": "*",
-				},
-			},
-			Response: CResponse{
-				StatusCode: 304,
-			},
-		}, {
-			Name: "GET for /ipfs/ dir listing with matching weak Etag in If-None-Match returns 304 Not Modified",
-			Request: CRequest{
-				Path: fmt.Sprintf("ipfs/%s/root2/root3/", fixture.MustGetCid()),
-				Headers: map[string]string{
-					"If-None-Match": fmt.Sprintf("W/\"%s\"", fixture.MustGetCid("root2", "root3")),
-				},
-			},
-			Response: CResponse{
-				StatusCode: 304,
-			},
+			Request: Request().
+				Path("ipfs/%s/root2/root3/root4/index.html", fixture.MustGetCid()).
+				Headers(
+					Header("If-None-Match", fmt.Sprintf("W/\"%s\"", fixture.MustGetCid("root2", "root3", "root4", "index.html"))),
+				),
+			Response: Expect().
+				Status(304),
 		},
-	}
+		{
+			Name: "GET for /ipfs/ file with wildcard Etag in If-None-Match returns 304 Not Modified",
+			Request: Request().
+				Path("ipfs/%s/root2/root3/root4/index.html", fixture.MustGetCid()).
+				Headers(
+					Header("If-None-Match", "*"),
+				),
+			Response: Expect().
+				Status(304),
+		},
+		{
+			Name: "GET for /ipfs/ dir listing with matching weak Etag in If-None-Match returns 304 Not Modified",
+			Request: Request().
+				Path("ipfs/%s/root2/root3/", fixture.MustGetCid()).
+				Headers(
+					Header("If-None-Match", fmt.Sprintf("W/\"%s\"", fixture.MustGetCid("root2", "root3"))),
+				),
+			Response: Expect().
+				Status(304),
+		},
+	}.Build()
 
 	Run(t, tests)
 }

--- a/tooling/test/config.go
+++ b/tooling/test/config.go
@@ -25,7 +25,6 @@ var SubdomainGatewayURL = strings.TrimRight(
 	GetEnv("SUBDOMAIN_GATEWAY_URL", "http://example.com"),
 	"/")
 
-
 var GatewayHost = ""
 var SubdomainGatewayHost = ""
 var SubdomainGatewayScheme = ""

--- a/tooling/test/report.go
+++ b/tooling/test/report.go
@@ -9,7 +9,6 @@ import (
 	"text/template"
 )
 
-
 type ReportInput struct {
 	Req  *http.Request
 	Res  *http.Response
@@ -53,7 +52,7 @@ func report(t *testing.T, test CTest, req *http.Request, res *http.Response, err
 			if v == nil {
 				return "nil"
 			}
-			
+
 			var b []byte
 			var err error
 			switch v := v.(type) {
@@ -71,7 +70,7 @@ func report(t *testing.T, test CTest, req *http.Request, res *http.Response, err
 			if err != nil {
 				panic(err)
 			}
-			
+
 			return string(b)
 		},
 	}).Parse(TEMPLATE)


### PR DESCRIPTION
This PR adds sugar to the t0116 implementation and adds missing test case implementations as comments.

The missing test case implementation cannot be uncommented yet because:
- we do not have support for IPNS records in fixtures
- we do not have support for handling dependencies between test cases