### PR TITLE
fix: return pointer in car check to be compatible with rest of API

### DIFF
--- a/tests/t0118_gateway_car_test.go
+++ b/tests/t0118_gateway_car_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/ipfs/gateway-conformance/tooling/car"
+	. "github.com/ipfs/gateway-conformance/tooling/check"
 	. "github.com/ipfs/gateway-conformance/tooling/test"
 )
 
@@ -41,6 +42,12 @@ func TestGatewayCar(t *testing.T) {
 					Header("Accept-Ranges").
 						Hint("CAR is streamed, gateway may not have the entire thing, unable to support range-requests. Partial downloads and resumes should be handled using IPLD selectors: https://github.com/ipfs/go-ipfs/issues/8769").
 						Equals("none"),
+				).Body(
+					IsCar().
+					 	HasRoot(fixture.MustGetCid("subdir", "ascii.txt")).
+						HasBlock(fixture.MustGetCid("subdir", "ascii.txt")).
+						Exactly().
+						InThatOrder(),	
 				),
 		},
 	}

--- a/tooling/check/car.go
+++ b/tooling/check/car.go
@@ -13,6 +13,8 @@ type CheckIsCarFile struct {
 	isOrdered bool
 }
 
+var _ Check[[]byte] = (*CheckIsCarFile)(nil)
+
 func IsCar() *CheckIsCarFile {
 	return &CheckIsCarFile{
 		blockCIDs: []cid.Cid{},
@@ -30,38 +32,38 @@ func decoded(cidStr string) cid.Cid {
 	return cid
 }
 
-func (c CheckIsCarFile) HasBlock(cidStr string) CheckIsCarFile {
+func (c CheckIsCarFile) HasBlock(cidStr string) *CheckIsCarFile {
 	c.blockCIDs = append(c.blockCIDs, decoded(cidStr))
-	return c
+	return &c
 }
 
-func (c CheckIsCarFile) HasBlocks(cidStrs ...string) CheckIsCarFile {
+func (c CheckIsCarFile) HasBlocks(cidStrs ...string) *CheckIsCarFile {
 	for _, cidStr := range cidStrs {
 		c.blockCIDs = append(c.blockCIDs, decoded(cidStr))
 	}
-	return c
+	return &c
 }
 
-func (c CheckIsCarFile) HasRoot(cidStr string) CheckIsCarFile {
+func (c CheckIsCarFile) HasRoot(cidStr string) *CheckIsCarFile {
 	c.rootCIDs = append(c.rootCIDs, decoded(cidStr))
-	return c
+	return &c
 }
 
-func (c CheckIsCarFile) HasRoots(cidStrs ...string) CheckIsCarFile {
+func (c CheckIsCarFile) HasRoots(cidStrs ...string) *CheckIsCarFile {
 	for _, cidStr := range cidStrs {
 		c.rootCIDs = append(c.rootCIDs, decoded(cidStr))
 	}
-	return c
+	return &c
 }
 
-func (c CheckIsCarFile) Exactly() CheckIsCarFile {
+func (c CheckIsCarFile) Exactly() *CheckIsCarFile {
 	c.isExact = true
-	return c
+	return &c
 }
 
-func (c CheckIsCarFile) InThatOrder() CheckIsCarFile {
+func (c CheckIsCarFile) InThatOrder() *CheckIsCarFile {
 	c.isOrdered = true
-	return c
+	return &c
 }
 
 func (c *CheckIsCarFile) Check(carContent []byte) CheckOutput {


### PR DESCRIPTION
Fixes the panic `body must be string, []byte, or a regular check` when we use a Car check.

- [x] Method on IsCar now return pointers instead of values which can be used in the `Body`
- [x] Add a test that relies on that API
