### PR TITLE
fix: remove the requirement on Content-Length on the gateway

### DIFF
--- a/tests/t0118_gateway_car_test.go
+++ b/tests/t0118_gateway_car_test.go
@@ -30,9 +30,6 @@ func TestGatewayCar(t *testing.T) {
 					Header("Content-Type").
 						Hint("Expected content type to be application/vnd.ipld.car").
 						Contains("application/vnd.ipld.car"),
-					Header("Content-Length").
-						Hint("CAR is streamed, gateway may not have the entire thing, unable to calculate total size").
-						IsEmpty(),
 					Header("Content-Disposition").
 						Hint(`Expected content disposition to be attachment; filename="<cid>.car"`).
 						Contains(`attachment; filename="{{cid}}.car"`, fixture.MustGetCid("subdir", "ascii.txt")),


### PR DESCRIPTION
This is not defined anywhere in the spec https://grep.app/search?q=Content-Length&filter[repo][0]=ipfs/specs and thus shouldn't be tested.

Sending a Content-Length header here is fine if the remote gateway knows the size of the car.

For example I am writing a very fast gateway that use indexed IPIP402 cars with a unixfs offset -> car offset index. This allows to use the `sendfile` syscall to send the car from the drives to the network card without copying it into memory or CPU. An index gives stores offset in the car for offsets in the unixfs file or directories, I need it to implement pathing (I skip parts of the car unrelevent to the request). I can then do a simple substraction and a few additions to get the total size of the car, if this is an info I have to compute anyway I might as well send it to the client. A client could use it to display an accurate download bar or preallocate correctly sized buffers, ...

If the car is stored in a caching reverse proxy that already knows it's full size it could want to send the Content-Length header for the same reasons.

The only consideration here is that sending a Content-Length which is missmatched with the underlying size would break things, which is true however this is a violation of the HTTP spec already because HTTP 1.1 pipelining depends on the Content-Length. The http client will catch this.