### PR TITLE
fix: remove body check for subdomain redirection

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -33,7 +33,7 @@ require (
 require (
 	github.com/go-logr/logr v1.2.4 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
-	github.com/gogo/protobuf v1.3.2
+	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/google/uuid v1.3.0 // indirect
 	github.com/hashicorp/golang-lru v0.5.4 // indirect
 	github.com/ipfs/bbloom v0.0.4 // indirect

--- a/tests/t0114_gateway_subdomains_test.go
+++ b/tests/t0114_gateway_subdomains_test.go
@@ -60,14 +60,6 @@ func TestGatewaySubdomains(t *testing.T) {
 					Header("Location").
 						Hint("request for example.com/ipfs/{CIDv1} returns Location HTTP header for subdomain redirect in browsers").
 						Contains("{{scheme}}://{{cid}}.ipfs.{{host}}/", u.Scheme, CIDv1, u.Host),
-				).
-				BodyWithHint(`
-					We return body with HTTP 301 so existing cli scripts that use path-based
-					gateway do not break (curl doesn't auto-redirect without passing -L; wget
-					does not span across hostnames by default)
-					Context: https://github.com/ipfs/go-ipfs/issues/6975
-				`,
-					IsEqual("hello\n"),
 				),
 		))
 


### PR DESCRIPTION
See the context in https://github.com/ipfs/boxo/pull/326.