### PR TITLE
feat: remove Kubo-specifics from RAW tests and add range tests

### DIFF
--- a/tests/trustless_gateway_raw_test.go
+++ b/tests/trustless_gateway_raw_test.go
@@ -49,7 +49,7 @@ func TestTrustlessRaw(t *testing.T) {
 					Header("Content-Length").
 						Equals("{{length}}", len(fixture.MustGetRawData("dir", "ascii.txt"))),
 					Header("Content-Disposition").
-						Matches(`attachment;\s*filename=".*\.bin"`),
+						Contains("attachment;"),
 					Header("X-Content-Type-Options").
 						Equals("nosniff"),
 				).
@@ -66,7 +66,9 @@ func TestTrustlessRaw(t *testing.T) {
 				Status(200).
 				Headers(
 					Header("Content-Disposition").
-						Matches(`attachment;\s*filename="foobar\.bin`),
+						Contains(`attachment;`),
+					Header("Content-Disposition").
+						Contains(`filename="foobar.bin`),
 				),
 		},
 		{
@@ -80,8 +82,7 @@ func TestTrustlessRaw(t *testing.T) {
 				Status(200).
 				Headers(
 					Header("Etag").
-						Hint("Etag must be present for caching purposes").
-						Not().IsEmpty(),
+						Exists(),
 					Header("X-IPFS-Path").
 						Equals("/ipfs/{{cid}}", fixture.MustGetCid("dir", "ascii.txt")),
 					Header("X-IPFS-Roots").


### PR DESCRIPTION
We should tick `t0117` from #3 after this PR.

- This tests were missing: https://github.com/ipfs/kubo/blob/master/test/sharness/t0117-gateway-block.sh#L32-L45
	- We should really start removing sharness tests from Kubo to avoid doing this again: we updated the tests after they were ported.
- Removed Kubo specifics.