### PR TITLE
feat: explicitly not check CAR roots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Changed
+- CAR tests no longer check for the roots. See discussion in [IPIP-402](https://github.com/ipfs/specs/pull/402).
+
 ## [0.1.0] - 2023-06-08
 ### Added
 - `Fmt` a string interpolation that replaces golang's and works better with HTML entities, and HTTP headers and URLs.

--- a/tests/trustless_gateway_car_test.go
+++ b/tests/trustless_gateway_car_test.go
@@ -30,8 +30,6 @@ func TestTrustlessCarPathing(t *testing.T) {
 				Status(200).
 				Body(
 					IsCar().
-						HasRoot(subdirTwoSingleBlockFilesFixture.MustGetCid("subdir", "ascii.txt")).
-						MightHaveNoRoots().
 						HasBlocks(
 							subdirTwoSingleBlockFilesFixture.MustGetCid(),
 							subdirTwoSingleBlockFilesFixture.MustGetCid("subdir"),
@@ -55,8 +53,6 @@ func TestTrustlessCarPathing(t *testing.T) {
 				Status(200).
 				Body(
 					IsCar().
-						HasRoot(singleLayerHamtMultiBlockFilesFixture.MustGetCid("685.txt")).
-						MightHaveNoRoots().
 						HasBlocks(flattenStrings(t,
 							singleLayerHamtMultiBlockFilesFixture.MustGetCid(),
 							singleLayerHamtMultiBlockFilesFixture.MustGetCIDsInHAMTTraversal(nil, "685.txt"),
@@ -81,8 +77,6 @@ func TestTrustlessCarPathing(t *testing.T) {
 				Status(200).
 				Body(
 					IsCar().
-						HasRoot(dirWithDagCborWithLinksFixture.MustGetCid("document", "files", "single")).
-						MightHaveNoRoots().
 						HasBlocks(flattenStrings(t,
 							dirWithDagCborWithLinksFixture.MustGetCid("document"),
 							dirWithDagCborWithLinksFixture.MustGetCid("document", "files", "single"),
@@ -115,8 +109,6 @@ func TestTrustlessCarDagScopeBlock(t *testing.T) {
 				Status(200).
 				Body(
 					IsCar().
-						HasRoot(subdirTwoSingleBlockFilesFixture.MustGetCid("subdir")).
-						MightHaveNoRoots().
 						HasBlocks(
 							subdirTwoSingleBlockFilesFixture.MustGetCid(),
 							subdirTwoSingleBlockFilesFixture.MustGetCid("subdir"),
@@ -139,8 +131,6 @@ func TestTrustlessCarDagScopeBlock(t *testing.T) {
 				Status(200).
 				Body(
 					IsCar().
-						HasRoot(subdirTwoSingleBlockFilesFixture.MustGetCid("subdir", "ascii.txt")).
-						MightHaveNoRoots().
 						HasBlocks(
 							subdirTwoSingleBlockFilesFixture.MustGetCid(),
 							subdirTwoSingleBlockFilesFixture.MustGetCid("subdir"),
@@ -166,8 +156,6 @@ func TestTrustlessCarDagScopeBlock(t *testing.T) {
 				Status(200).
 				Body(
 					IsCar().
-						HasRoot(singleLayerHamtMultiBlockFilesFixture.MustGetCid("1.txt")).
-						MightHaveNoRoots().
 						HasBlocks(flattenStrings(t,
 							singleLayerHamtMultiBlockFilesFixture.MustGetCid(),
 							singleLayerHamtMultiBlockFilesFixture.MustGetCIDsInHAMTTraversal(nil, "1.txt"),
@@ -203,8 +191,6 @@ func TestTrustlessCarDagScopeEntity(t *testing.T) {
 				Status(200).
 				Body(
 					IsCar().
-						HasRoot(subdirTwoSingleBlockFilesFixture.MustGetCid()).
-						MightHaveNoRoots().
 						HasBlocks(
 							subdirTwoSingleBlockFilesFixture.MustGetCid(),
 						).
@@ -226,8 +212,6 @@ func TestTrustlessCarDagScopeEntity(t *testing.T) {
 				Status(200).
 				Body(
 					IsCar().
-						HasRoot(singleLayerHamtMultiBlockFilesFixture.MustGetCid()).
-						MightHaveNoRoots().
 						HasBlocks(
 							flattenStrings(t,
 								singleLayerHamtMultiBlockFilesFixture.MustGetCid(),
@@ -251,8 +235,6 @@ func TestTrustlessCarDagScopeEntity(t *testing.T) {
 				Status(200).
 				Body(
 					IsCar().
-						HasRoot(subdirWithMixedBlockFiles.MustGetCid("subdir", "ascii.txt")).
-						MightHaveNoRoots().
 						HasBlocks(
 							flattenStrings(t,
 								subdirWithMixedBlockFiles.MustGetCid(),
@@ -278,8 +260,6 @@ func TestTrustlessCarDagScopeEntity(t *testing.T) {
 				Status(200).
 				Body(
 					IsCar().
-						HasRoot(subdirWithMixedBlockFiles.MustGetCid("subdir", "multiblock.txt")).
-						MightHaveNoRoots().
 						HasBlocks(
 							flattenStrings(t,
 								subdirWithMixedBlockFiles.MustGetCid(),
@@ -306,8 +286,6 @@ func TestTrustlessCarDagScopeEntity(t *testing.T) {
 				Status(200).
 				Body(
 					IsCar().
-						HasRoot(dirWithDagCborWithLinksFixture.MustGetCid("document")).
-						MightHaveNoRoots().
 						HasBlocks(flattenStrings(t,
 							dirWithDagCborWithLinksFixture.MustGetCid(),
 							dirWithDagCborWithLinksFixture.MustGetCid("document"),
@@ -339,8 +317,6 @@ func TestTrustlessCarDagScopeAll(t *testing.T) {
 				Status(200).
 				Body(
 					IsCar().
-						HasRoot(subdirWithMixedBlockFiles.MustGetCid("subdir")).
-						MightHaveNoRoots().
 						HasBlocks(
 							flattenStrings(
 								t,
@@ -367,8 +343,6 @@ func TestTrustlessCarDagScopeAll(t *testing.T) {
 				Status(200).
 				Body(
 					IsCar().
-						HasRoot(subdirWithMixedBlockFiles.MustGetCid("subdir", "multiblock.txt")).
-						MightHaveNoRoots().
 						HasBlocks(
 							flattenStrings(t,
 								subdirWithMixedBlockFiles.MustGetCid(),
@@ -406,8 +380,6 @@ func TestTrustlessCarEntityBytes(t *testing.T) {
 				Status(200).
 				Body(
 					IsCar().
-						HasRoot(subdirWithMixedBlockFiles.MustGetCid("subdir", "multiblock.txt")).
-						MightHaveNoRoots().
 						HasBlocks(flattenStrings(t,
 							subdirWithMixedBlockFiles.MustGetCid(),
 							subdirWithMixedBlockFiles.MustGetCid("subdir"),
@@ -434,8 +406,6 @@ func TestTrustlessCarEntityBytes(t *testing.T) {
 				Status(200).
 				Body(
 					IsCar().
-						HasRoot(singleLayerHamtMultiBlockFilesFixture.MustGetCid()).
-						MightHaveNoRoots().
 						HasBlocks(
 							flattenStrings(t,
 								singleLayerHamtMultiBlockFilesFixture.MustGetCid(),
@@ -459,8 +429,6 @@ func TestTrustlessCarEntityBytes(t *testing.T) {
 				Status(200).
 				Body(
 					IsCar().
-						HasRoot(subdirWithMixedBlockFiles.MustGetCid("subdir", "multiblock.txt")).
-						MightHaveNoRoots().
 						HasBlocks(
 							flattenStrings(t,
 								subdirWithMixedBlockFiles.MustGetCid("subdir", "multiblock.txt"),
@@ -484,8 +452,6 @@ func TestTrustlessCarEntityBytes(t *testing.T) {
 				Status(200).
 				Body(
 					IsCar().
-						HasRoot(subdirWithMixedBlockFiles.MustGetCid("subdir", "multiblock.txt")).
-						MightHaveNoRoots().
 						HasBlocks(
 							flattenStrings(t,
 								subdirWithMixedBlockFiles.MustGetCid("subdir", "multiblock.txt"),
@@ -509,8 +475,6 @@ func TestTrustlessCarEntityBytes(t *testing.T) {
 				Status(200).
 				Body(
 					IsCar().
-						HasRoot(subdirWithMixedBlockFiles.MustGetCid("subdir", "multiblock.txt")).
-						MightHaveNoRoots().
 						HasBlocks(
 							flattenStrings(t,
 								subdirWithMixedBlockFiles.MustGetCid("subdir", "multiblock.txt"),
@@ -534,8 +498,6 @@ func TestTrustlessCarEntityBytes(t *testing.T) {
 				Status(200).
 				Body(
 					IsCar().
-						HasRoot(subdirWithMixedBlockFiles.MustGetCid("subdir", "multiblock.txt")).
-						MightHaveNoRoots().
 						HasBlocks(
 							flattenStrings(t,
 								subdirWithMixedBlockFiles.MustGetCid("subdir", "multiblock.txt"),
@@ -559,8 +521,6 @@ func TestTrustlessCarEntityBytes(t *testing.T) {
 				Status(200).
 				Body(
 					IsCar().
-						HasRoot(subdirWithMixedBlockFiles.MustGetCid("subdir", "multiblock.txt")).
-						MightHaveNoRoots().
 						HasBlocks(
 							flattenStrings(t,
 								subdirWithMixedBlockFiles.MustGetCid("subdir", "multiblock.txt"),
@@ -584,8 +544,6 @@ func TestTrustlessCarEntityBytes(t *testing.T) {
 				Status(200).
 				Body(
 					IsCar().
-						HasRoot(subdirWithMixedBlockFiles.MustGetCid("subdir", "multiblock.txt")).
-						MightHaveNoRoots().
 						HasBlocks(
 							flattenStrings(t,
 								subdirWithMixedBlockFiles.MustGetCid("subdir", "multiblock.txt"),

--- a/tests/trustless_gateway_car_test.go
+++ b/tests/trustless_gateway_car_test.go
@@ -30,6 +30,7 @@ func TestTrustlessCarPathing(t *testing.T) {
 				Status(200).
 				Body(
 					IsCar().
+						IgnoreRoots().
 						HasBlocks(
 							subdirTwoSingleBlockFilesFixture.MustGetCid(),
 							subdirTwoSingleBlockFilesFixture.MustGetCid("subdir"),
@@ -53,6 +54,7 @@ func TestTrustlessCarPathing(t *testing.T) {
 				Status(200).
 				Body(
 					IsCar().
+						IgnoreRoots().
 						HasBlocks(flattenStrings(t,
 							singleLayerHamtMultiBlockFilesFixture.MustGetCid(),
 							singleLayerHamtMultiBlockFilesFixture.MustGetCIDsInHAMTTraversal(nil, "685.txt"),
@@ -77,6 +79,7 @@ func TestTrustlessCarPathing(t *testing.T) {
 				Status(200).
 				Body(
 					IsCar().
+						IgnoreRoots().
 						HasBlocks(flattenStrings(t,
 							dirWithDagCborWithLinksFixture.MustGetCid("document"),
 							dirWithDagCborWithLinksFixture.MustGetCid("document", "files", "single"),
@@ -109,6 +112,7 @@ func TestTrustlessCarDagScopeBlock(t *testing.T) {
 				Status(200).
 				Body(
 					IsCar().
+						IgnoreRoots().
 						HasBlocks(
 							subdirTwoSingleBlockFilesFixture.MustGetCid(),
 							subdirTwoSingleBlockFilesFixture.MustGetCid("subdir"),
@@ -131,6 +135,7 @@ func TestTrustlessCarDagScopeBlock(t *testing.T) {
 				Status(200).
 				Body(
 					IsCar().
+						IgnoreRoots().
 						HasBlocks(
 							subdirTwoSingleBlockFilesFixture.MustGetCid(),
 							subdirTwoSingleBlockFilesFixture.MustGetCid("subdir"),
@@ -156,6 +161,7 @@ func TestTrustlessCarDagScopeBlock(t *testing.T) {
 				Status(200).
 				Body(
 					IsCar().
+						IgnoreRoots().
 						HasBlocks(flattenStrings(t,
 							singleLayerHamtMultiBlockFilesFixture.MustGetCid(),
 							singleLayerHamtMultiBlockFilesFixture.MustGetCIDsInHAMTTraversal(nil, "1.txt"),
@@ -191,6 +197,7 @@ func TestTrustlessCarDagScopeEntity(t *testing.T) {
 				Status(200).
 				Body(
 					IsCar().
+						IgnoreRoots().
 						HasBlocks(
 							subdirTwoSingleBlockFilesFixture.MustGetCid(),
 						).
@@ -212,6 +219,7 @@ func TestTrustlessCarDagScopeEntity(t *testing.T) {
 				Status(200).
 				Body(
 					IsCar().
+						IgnoreRoots().
 						HasBlocks(
 							flattenStrings(t,
 								singleLayerHamtMultiBlockFilesFixture.MustGetCid(),
@@ -235,6 +243,7 @@ func TestTrustlessCarDagScopeEntity(t *testing.T) {
 				Status(200).
 				Body(
 					IsCar().
+						IgnoreRoots().
 						HasBlocks(
 							flattenStrings(t,
 								subdirWithMixedBlockFiles.MustGetCid(),
@@ -260,6 +269,7 @@ func TestTrustlessCarDagScopeEntity(t *testing.T) {
 				Status(200).
 				Body(
 					IsCar().
+						IgnoreRoots().
 						HasBlocks(
 							flattenStrings(t,
 								subdirWithMixedBlockFiles.MustGetCid(),
@@ -286,6 +296,7 @@ func TestTrustlessCarDagScopeEntity(t *testing.T) {
 				Status(200).
 				Body(
 					IsCar().
+						IgnoreRoots().
 						HasBlocks(flattenStrings(t,
 							dirWithDagCborWithLinksFixture.MustGetCid(),
 							dirWithDagCborWithLinksFixture.MustGetCid("document"),
@@ -317,6 +328,7 @@ func TestTrustlessCarDagScopeAll(t *testing.T) {
 				Status(200).
 				Body(
 					IsCar().
+						IgnoreRoots().
 						HasBlocks(
 							flattenStrings(
 								t,
@@ -343,6 +355,7 @@ func TestTrustlessCarDagScopeAll(t *testing.T) {
 				Status(200).
 				Body(
 					IsCar().
+						IgnoreRoots().
 						HasBlocks(
 							flattenStrings(t,
 								subdirWithMixedBlockFiles.MustGetCid(),
@@ -380,6 +393,7 @@ func TestTrustlessCarEntityBytes(t *testing.T) {
 				Status(200).
 				Body(
 					IsCar().
+						IgnoreRoots().
 						HasBlocks(flattenStrings(t,
 							subdirWithMixedBlockFiles.MustGetCid(),
 							subdirWithMixedBlockFiles.MustGetCid("subdir"),
@@ -406,6 +420,7 @@ func TestTrustlessCarEntityBytes(t *testing.T) {
 				Status(200).
 				Body(
 					IsCar().
+						IgnoreRoots().
 						HasBlocks(
 							flattenStrings(t,
 								singleLayerHamtMultiBlockFilesFixture.MustGetCid(),
@@ -429,6 +444,7 @@ func TestTrustlessCarEntityBytes(t *testing.T) {
 				Status(200).
 				Body(
 					IsCar().
+						IgnoreRoots().
 						HasBlocks(
 							flattenStrings(t,
 								subdirWithMixedBlockFiles.MustGetCid("subdir", "multiblock.txt"),
@@ -452,6 +468,7 @@ func TestTrustlessCarEntityBytes(t *testing.T) {
 				Status(200).
 				Body(
 					IsCar().
+						IgnoreRoots().
 						HasBlocks(
 							flattenStrings(t,
 								subdirWithMixedBlockFiles.MustGetCid("subdir", "multiblock.txt"),
@@ -475,6 +492,7 @@ func TestTrustlessCarEntityBytes(t *testing.T) {
 				Status(200).
 				Body(
 					IsCar().
+						IgnoreRoots().
 						HasBlocks(
 							flattenStrings(t,
 								subdirWithMixedBlockFiles.MustGetCid("subdir", "multiblock.txt"),
@@ -498,6 +516,7 @@ func TestTrustlessCarEntityBytes(t *testing.T) {
 				Status(200).
 				Body(
 					IsCar().
+						IgnoreRoots().
 						HasBlocks(
 							flattenStrings(t,
 								subdirWithMixedBlockFiles.MustGetCid("subdir", "multiblock.txt"),
@@ -521,6 +540,7 @@ func TestTrustlessCarEntityBytes(t *testing.T) {
 				Status(200).
 				Body(
 					IsCar().
+						IgnoreRoots().
 						HasBlocks(
 							flattenStrings(t,
 								subdirWithMixedBlockFiles.MustGetCid("subdir", "multiblock.txt"),
@@ -544,6 +564,7 @@ func TestTrustlessCarEntityBytes(t *testing.T) {
 				Status(200).
 				Body(
 					IsCar().
+						IgnoreRoots().
 						HasBlocks(
 							flattenStrings(t,
 								subdirWithMixedBlockFiles.MustGetCid("subdir", "multiblock.txt"),

--- a/tooling/check/car.go
+++ b/tooling/check/car.go
@@ -9,6 +9,7 @@ import (
 type CheckIsCarFile struct {
 	blockCIDs        []cid.Cid
 	rootCIDs         []cid.Cid
+	ignoreRoots      bool
 	mightHaveNoRoots bool
 	isExact          bool
 	isOrdered        bool
@@ -62,6 +63,11 @@ func (c CheckIsCarFile) MightHaveNoRoots() *CheckIsCarFile {
 	return &c
 }
 
+func (c CheckIsCarFile) IgnoreRoots() *CheckIsCarFile {
+	c.ignoreRoots = true
+	return &c
+}
+
 func (c CheckIsCarFile) Exactly() *CheckIsCarFile {
 	c.isExact = true
 	return &c
@@ -101,7 +107,7 @@ func (c *CheckIsCarFile) Check(carContent []byte) CheckOutput {
 		return output
 	}
 
-	if len(c.rootCIDs) > 0 || c.isExact {
+	if (len(c.rootCIDs) > 0 || c.isExact) && !c.ignoreRoots {
 		gotRoots, err := listAllRoots(carContent)
 		if err != nil {
 			return CheckOutput{


### PR DESCRIPTION
Closes #83.

I had to add a `IgnoreRoots` option because the way the current CAR checks work, we **always** have to say something about the roots if we do a `Exactly`. So now you can ignore CAR roots on Exactly. Nevertheless, the logic for `CheckIsCarFile.Check` is getting quite hairy.