### PR TITLE
release: v0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,14 +5,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+
+## [0.2.0] - 2023-06-26
 ### Added
 - `carFixture.MustGetChildren`
 - Gateway backend timeout test for entity-bytes from IPIP-402. [Issue](https://github.com/ipfs/gateway-conformance/issues/75).
 
 ### Changed
 - Renamed methods using `Children` into `Descendants` when relevant
-
-### Changed
 - CAR tests no longer check for the roots. See discussion in [IPIP-402](https://github.com/ipfs/specs/pull/402).
 
 ## [0.1.0] - 2023-06-08


### PR DESCRIPTION
Closes https://github.com/ipfs/gateway-conformance/issues/80

After release:
- [ ] Upgrade kubo and boxo to load domains AND subdomains DNSLinks (see [PR](https://github.com/ipfs/gateway-conformance/pull/53/files#diff-41f34cd4fcf57bd8b77f08880e94fe08ae40bf31084f70717d621372d9ddbc45))
- [ ] Upgrade kubo and boxo to use `dag import .... --pin-roots=false` (See [PR](https://github.com/ipfs/gateway-conformance/pull/85))
