### PR TITLE
chore: retrieve UX improvements from IPFS Thing 2023 workshop setup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Added
+- `--verbose` flag displays all the output to the console
 
 ## [0.2.0] - 2023-06-26
 ### Added

--- a/Makefile
+++ b/Makefile
@@ -1,32 +1,32 @@
 all: test-kubo
 
 test-cargateway: provision-cargateway fixtures.car gateway-conformance
-	./gateway-conformance test --json output.json --gateway-url http://127.0.0.1:8040 --specs -subdomain-gateway
+	./gateway-conformance test --json reports/output.json --gateway-url http://127.0.0.1:8040 --specs -subdomain-gateway
 
 test-kubo-subdomains: provision-kubo gateway-conformance
 	./kubo-config.example.sh
-	./gateway-conformance test --json output.json --gateway-url http://127.0.0.1:8080 --subdomain-url http://example.com:8080
+	./gateway-conformance test --json reports/output.json --gateway-url http://127.0.0.1:8080 --subdomain-url http://example.com:8080
 
-test-kubo: provision-kubo fixtures.car gateway-conformance
-	./gateway-conformance test --json output.json --gateway-url http://127.0.0.1:8080 --specs -subdomain-gateway
+test-kubo: provision-kubo gateway-conformance
+	./gateway-conformance test --json reports/output.json --gateway-url http://127.0.0.1:8080 --specs -subdomain-gateway
 
 provision-cargateway: ./fixtures.car
 	# cd go-libipfs/examples/car && go install
 	car -c ./fixtures.car &
 
-provision-kubo: fixtures.car
+provision-kubo:
 	find ./fixtures -name '*.car' -exec ipfs dag import {} \;
 	find ./fixtures -name '*.ipns-record' -exec sh -c 'ipfs routing put --allow-offline /ipns/$$(basename -s .ipns-record "{}") "{}"' \;
 
+# tools
 fixtures.car: gateway-conformance
 	./gateway-conformance extract-fixtures --merged=true --dir=.
 
 gateway-conformance:
 	go build -o ./gateway-conformance ./cmd/gateway-conformance
 
-test-docker: fixtures.car gateway-conformance
-	docker build -t gateway-conformance .
-	docker run --rm -v "${PWD}:/workspace" -w "/workspace" --network=host gateway-conformance test
+test-docker: docker fixtures.car gateway-conformance
+	./gc test
 
 output.xml: test-kubo
 	docker run --rm -v "${PWD}:/workspace" -w "/workspace" --entrypoint "/bin/bash" ghcr.io/pl-strflt/saxon:v1 -c """
@@ -36,5 +36,8 @@ output.xml: test-kubo
 output.html: output.xml
 	docker run --rm -v "${PWD}:/workspace" -w "/workspace" ghcr.io/pl-strflt/saxon:v1 -s:output.xml -xsl:/etc/junit-noframes-saxon.xsl -o:output.html
 	open ./output.html
+
+docker:
+	docker build -t gateway-conformance .
 
 .PHONY: gateway-conformance

--- a/cmd/gateway-conformance/main.go
+++ b/cmd/gateway-conformance/main.go
@@ -24,10 +24,17 @@ type event struct {
 
 type out struct {
 	Writer io.Writer
+	Filter func(s string) bool
 }
 
 func (o out) Write(p []byte) (n int, err error) {
-	os.Stdout.Write(p)
+	if o.Filter != nil {
+		for _, line := range strings.Split(string(p), "\n") {
+			if o.Filter(line) {
+				os.Stdout.Write([]byte(fmt.Sprintf("%s\n", line)))
+			}
+		}
+	}
 	return o.Writer.Write(p)
 }
 
@@ -52,6 +59,7 @@ func copyFiles(inputPaths []string, outputDirectoryPath string) error {
 		newName := fmt.Sprintf("%s_%d%s", name, i, ext)
 
 		outputPath := filepath.Join(outputDirectoryPath, newName)
+
 		dst, err := os.Create(outputPath)
 		if err != nil {
 			return err
@@ -72,6 +80,7 @@ func main() {
 	var specs string
 	var directory string
 	var merged bool
+	var verbose bool
 
 	app := &cli.App{
 		Name:  "gateway-conformance",
@@ -108,6 +117,12 @@ func main() {
 						Value:       "",
 						Destination: &specs,
 					},
+					&cli.BoolFlag{
+						Name: "verbose",
+						Usage: "Prints all the output to the console.",
+						Value:       false,
+						Destination: &verbose,
+					},
 				},
 				Action: func(cCtx *cli.Context) error {
 					args := []string{"test", "./tests", "-test.v=test2json"}
@@ -129,9 +144,37 @@ func main() {
 						cmd.Env = append(cmd.Env, fmt.Sprintf("SUBDOMAIN_GATEWAY_URL=%s", subdomainGatewayURL))
 					}
 
-					cmd.Stdout = out{output}
+					cmd.Stdout = out{
+						Writer: output,
+						Filter: func(line string) bool {
+							return verbose || strings.Contains(line, "FAIL") || strings.HasPrefix(line, "PASS")
+						},
+					}
 					cmd.Stderr = os.Stderr
+
+					fmt.Println("Running tests...\n")
 					testErr := cmd.Run()
+					fmt.Println("\nDONE!\n")
+
+					if testErr != nil {
+						fmt.Println("\nLooking for details...\n")
+						strOutput := output.String()
+						lineDump := []string{}
+						for _, line := range strings.Split(strOutput, "\n") {
+							if strings.Contains(line, "FAIL") {
+								fmt.Println(line)
+								for _, l := range lineDump {
+									fmt.Println(l)
+								}
+								lineDump = []string{}
+							} else if strings.Contains(line, "===") {
+								lineDump = []string{}
+							} else {
+								lineDump = append(lineDump, line)
+							}
+						}
+						fmt.Println("\nDONE!\n")
+					}
 
 					if jsonOutput != "" {
 						json := &bytes.Buffer{}
@@ -139,7 +182,14 @@ func main() {
 						cmd.Stdin = output
 						cmd.Stdout = json
 						cmd.Stderr = os.Stderr
+
+						fmt.Println("\nGenerating JSON report...")
 						err := cmd.Run()
+						if err != nil {
+							return err
+						}
+						// create directory if it doesn't exist
+						err = os.MkdirAll(filepath.Dir(jsonOutput), 0755)
 						if err != nil {
 							return err
 						}
@@ -153,6 +203,7 @@ func main() {
 						if err != nil {
 							return err
 						}
+						fmt.Println("DONE!\n")
 					}
 
 					return testErr

--- a/cmd/gateway-conformance/main.go
+++ b/cmd/gateway-conformance/main.go
@@ -147,7 +147,10 @@ func main() {
 					cmd.Stdout = out{
 						Writer: output,
 						Filter: func(line string) bool {
-							return verbose || strings.Contains(line, "FAIL") || strings.HasPrefix(line, "PASS")
+							return verbose ||
+								strings.HasPrefix(line, "\u0016FAIL") ||
+								strings.HasPrefix(line, "\u0016--- FAIL") ||
+								strings.HasPrefix(line, "\u0016PASS")
 						},
 					}
 					cmd.Stderr = os.Stderr
@@ -161,13 +164,13 @@ func main() {
 						strOutput := output.String()
 						lineDump := []string{}
 						for _, line := range strings.Split(strOutput, "\n") {
-							if strings.Contains(line, "FAIL") {
+							if strings.HasPrefix(line, "\u0016FAIL") || strings.HasPrefix(line, "\u0016--- FAIL") {
 								fmt.Println(line)
 								for _, l := range lineDump {
 									fmt.Println(l)
 								}
 								lineDump = []string{}
-							} else if strings.Contains(line, "===") {
+							} else if strings.HasPrefix(line, "\u0016===") {
 								lineDump = []string{}
 							} else {
 								lineDump = append(lineDump, line)

--- a/gc
+++ b/gc
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+docker run --rm -v "${PWD}:/workspace" -w "/workspace" --network=host gateway-conformance "$@"

--- a/tooling/test/report.go
+++ b/tooling/test/report.go
@@ -3,6 +3,7 @@ package test
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httputil"
 	"testing"
@@ -22,14 +23,14 @@ Hint: {{.Test.Hint}}
 
 Error: {{.Err}}
 
-Request:
+Expected Request:
 {{.Test.Request | json}}
-
-Expected Response:
-{{.Test.Response | json}}
 
 Actual Request:
 {{.Req | dump}}
+
+Expected Response:
+{{.Test.Response | json}}
 
 Actual Response:
 {{.Res | dump}}
@@ -91,7 +92,7 @@ func report(t *testing.T, test SugarTest, req *http.Request, res *http.Response,
 	var buf bytes.Buffer
 	err = tmpl.Execute(&buf, input)
 	if err != nil {
-		panic(err)
+		panic(fmt.Errorf("failed to execute template: %#v %w", input, err))
 	}
 
 	if input.Err != nil {


### PR DESCRIPTION
Changes include:
- making sure Makefile commands create reports in the `reports` directory which is properly gitignored
- extracting docker build out of `test-docker` command
- filtering out the go test output so that it only shows failures by defult
- adding verbose flag to the test command which makes sure we show ALL go test output
- enriching test command output with information about stage transitions
- ensuring output directories exist
- switching the order of expected/actual requests/responses in the report