### PR TITLE
feat: added support for modifying request/response before/after making the request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Added
+- Support for modifying the request before sending it to the gateway.
+- Support for modifying the response before comparing it to the expected response.
 
 ## [0.2.0] - 2023-06-26
 ### Added

--- a/tests/path_gateway_unixfs_test.go
+++ b/tests/path_gateway_unixfs_test.go
@@ -3,6 +3,7 @@ package tests
 import (
 	"fmt"
 	"net/http"
+	"strings"
 	"testing"
 
 	"github.com/ipfs/gateway-conformance/tooling/car"
@@ -128,7 +129,7 @@ func TestGatewayCache(t *testing.T) {
 						Matches("DirIndex-.*_CID-{{cid}}", fixture.MustGetCid("root2", "root3")),
 				),
 			After: func(res *http.Response) error {
-				etag = res.Header.Get("Etag")
+				etag = strings.ReplaceAll(res.Header.Get("Etag"), `"`, "")
 				return nil
 			},
 		},

--- a/tests/path_gateway_unixfs_test.go
+++ b/tests/path_gateway_unixfs_test.go
@@ -301,7 +301,7 @@ func TestGatewayCache(t *testing.T) {
 				if etag == "" {
 					return fmt.Errorf("etag is empty")
 				}
-				req.Header.Add("If-None-Match", fmt.Sprintf(`"{{%s}}"`, etag))
+				req.Header.Add("If-None-Match", fmt.Sprintf(`"%s"`, etag))
 				return nil
 			},
 		},
@@ -315,7 +315,7 @@ func TestGatewayCache(t *testing.T) {
 				if etag == "" {
 					return fmt.Errorf("etag is empty")
 				}
-				req.Header.Add("If-None-Match", fmt.Sprintf(`W/"{{%s}}"`, etag))
+				req.Header.Add("If-None-Match", fmt.Sprintf(`W/"%s"`, etag))
 				return nil
 			},
 		},

--- a/tooling/test/run.go
+++ b/tooling/test/run.go
@@ -97,13 +97,26 @@ func runRequest(ctx context.Context, t *testing.T, test SugarTest, builder Reque
 		}
 	}
 
+	if test.Before != nil {
+		err = test.Before(req)
+		if err != nil {
+			localReport(t, "Before failed: %s", err)
+		}
+	}
+
 	// send request
 	log.Debugf("Querying %s", url)
 	req = req.WithContext(ctx)
-
 	res, err = client.Do(req)
 	if err != nil {
 		localReport(t, "Querying %s failed: %s", url, err)
+	}
+
+	if test.After != nil {
+		err = test.After(res)
+		if err != nil {
+			localReport(t, "After failed: %s", err)
+		}
 	}
 
 	return req, res, localReport

--- a/tooling/test/test.go
+++ b/tooling/test/test.go
@@ -9,6 +9,9 @@ import (
 	"github.com/ipfs/gateway-conformance/tooling/specs"
 )
 
+type BeforeFunc func(req *http.Request) error
+type AfterFunc func(res *http.Response) error
+
 type SugarTest struct {
 	Name      string
 	Hint      string
@@ -16,6 +19,8 @@ type SugarTest struct {
 	Requests  []RequestBuilder
 	Response  ExpectBuilder
 	Responses ExpectsBuilder
+	Before    BeforeFunc
+	After     AfterFunc
 }
 
 type SugarTests []SugarTest


### PR DESCRIPTION
This PR adds support for modifying request/response before/after making the request. This enables porting t0116 test cases that depend on reading the value of the Etag header and using it in subsequent requests. 