### PR TITLE
fix: local workflow

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,14 +28,13 @@ gateway-conformance:
 test-docker: docker fixtures.car gateway-conformance
 	./gc test
 
-output.xml: test-kubo
-	docker run --rm -v "${PWD}:/workspace" -w "/workspace" --entrypoint "/bin/bash" ghcr.io/pl-strflt/saxon:v1 -c """
-		java -jar /opt/SaxonHE11-5J/saxon-he-11.5.jar -s:<(jq -s '.' output.json) -xsl:/etc/gotest.xsl -o:output.xml
-	"""
-
+output.xml:
+	jq -ns 'inputs' ./reports/output.json > ./reports/output.json.alt
+	docker run --rm -v "${PWD}:/workspace" -w "/workspace" ghcr.io/pl-strflt/saxon:v1 -json:"./reports/output.json.alt" -xsl:/etc/gotest.xsl -o:"./reports/output.xml"
+	
 output.html: output.xml
-	docker run --rm -v "${PWD}:/workspace" -w "/workspace" ghcr.io/pl-strflt/saxon:v1 -s:output.xml -xsl:/etc/junit-noframes-saxon.xsl -o:output.html
-	open ./output.html
+	docker run --rm -v "${PWD}:/workspace" -w "/workspace" ghcr.io/pl-strflt/saxon:v1 -s:./reports/output.xml -xsl:/etc/junit-noframes-saxon.xsl -o:./reports/output.html
+	open ./reports/output.html
 
 docker:
 	docker build -t gateway-conformance .

--- a/Makefile
+++ b/Makefile
@@ -28,11 +28,11 @@ gateway-conformance:
 test-docker: docker fixtures.car gateway-conformance
 	./gc test
 
-output.xml:
+./reports/output.xml: ./reports/output.json
 	jq -ns 'inputs' ./reports/output.json > ./reports/output.json.alt
 	docker run --rm -v "${PWD}:/workspace" -w "/workspace" ghcr.io/pl-strflt/saxon:v1 -json:"./reports/output.json.alt" -xsl:/etc/gotest.xsl -o:"./reports/output.xml"
 	
-output.html: output.xml
+./reports/output.html: ./reports/output.xml
 	docker run --rm -v "${PWD}:/workspace" -w "/workspace" ghcr.io/pl-strflt/saxon:v1 -s:./reports/output.xml -xsl:/etc/junit-noframes-saxon.xsl -o:./reports/output.html
 	open ./reports/output.html
 

--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ Here is an example for VSCode, `example.com` is the domain configured via [kubo-
 
 With this configuration, the tests will appear in `Testing` on VSCode's left sidebar.
 
-It's also possible to run test suite locally and use `make output.html` to generate a human-readable report from the test results in `reports/output.json`.
+It's also possible to run test suite locally and use `make ./reports/output.html` to generate a human-readable report from the test results in `reports/output.json`.
 
 ## Examples
 

--- a/README.md
+++ b/README.md
@@ -196,6 +196,8 @@ Here is an example for VSCode, `example.com` is the domain configured via [kubo-
 
 With this configuration, the tests will appear in `Testing` on VSCode's left sidebar.
 
+It's also possible to run test suite locally and use `make output.html` to generate a human-readable report from the test results in `reports/output.json`.
+
 ## Examples
 
 The examples are going to use `gateway-conformance` as a wrapper over `docker run -v "${PWD}:/workspace" -w "/workspace" ghcr.io/ipfs/gateway-conformance` for simplicity.


### PR DESCRIPTION
See https://github.com/pl-strflt/gotest-json-to-junit-xml/blob/main/gotest-json-to-junit-xml

Note: I dropped the dependency on `test-kubo`, the workflow might be used even by those testing a different gateway,

(see @aschmahmann request in https://filecoinproject.slack.com/archives/C050BPMU4SV/p1688137864882569)

## follow-up task

- [ ] run this in the CI to make sure we keep it up-to-date - https://github.com/ipfs/gateway-conformance/issues/106