### PR TITLE
feat: test production gateways

### DIFF
--- a/.github/workflows/release-fixtures.yml
+++ b/.github/workflows/release-fixtures.yml
@@ -1,0 +1,20 @@
+name: Release Fixtures
+on:
+  workflow_dispatch:
+  workflow_run:
+    workflows: [Release]
+    types:
+      - completed
+    
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - id: generate-fixtures
+        env:
+          W3STORAGE_TOKEN: ${{ secrets.W3STORAGE_TOKEN }}
+        uses: bash
+        run: |
+          make fixtures.car
+          curl -X POST 'https://api.web3.storage/car' # token should be in W3STORAGE_TOKEN

--- a/.github/workflows/release-fixtures.yml
+++ b/.github/workflows/release-fixtures.yml
@@ -11,10 +11,13 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - id: generate-fixtures
+      - name: Ganerate Fixtures
         env:
           W3STORAGE_TOKEN: ${{ secrets.W3STORAGE_TOKEN }}
-        uses: bash
         run: |
           make fixtures.car
-          curl -X POST 'https://api.web3.storage/car' # token should be in W3STORAGE_TOKEN
+      - name: Upload fixtures
+        uses: web3-storage/add-to-web3@v2
+        with:
+          web3_token: ${{ secrets.W3STORAGE_TOKEN }}
+          path_to_add: 'fixtures.car'

--- a/.github/workflows/test-prod-e2e.yml
+++ b/.github/workflows/test-prod-e2e.yml
@@ -48,14 +48,21 @@ jobs:
           set -o pipefail
 
           pin_status=""
+          start_time=$(date +%s)
+          timeout=$((2 * 60)) # Timeout set to 2 minutes
 
           while [[ "$pin_status" != "Pinned" ]]; do
             response=$(curl --fail --oauth2-bearer "$W3STORAGE_TOKEN" "https://api.web3.storage/status/$CID")
             pin_status=$(echo $response | jq -r '.pins[0].status')
             echo "Current pin status: $pin_status"
 
-            if [[ "$pin_status" != "Pinned" ]]; then
+            current_time=$(date +%s)
+            elapsed_time=$((current_time - start_time))
+
+            if [[ "$pin_status" != "Pinned" && $elapsed_time -lt $timeout ]]; then
               sleep 10 # Sleep for 10 seconds before trying again
+            else
+              break
             fi
           done
   test:

--- a/.github/workflows/test-prod-e2e.yml
+++ b/.github/workflows/test-prod-e2e.yml
@@ -68,7 +68,6 @@ jobs:
   test:
     runs-on: "ubuntu-latest"
     strategy:
-      fail-fast: false
       matrix:
         target: ["ipfs.runfission.com", "w3s.link"]
     defaults:
@@ -110,8 +109,8 @@ jobs:
   aggregate:
     runs-on: "ubuntu-latest"
     needs: [test]
-    strategy:
-      fail-fast: true
+    # the tests might have failed
+    if: always()
     defaults:
       run:
         shell: bash

--- a/.github/workflows/test-prod-e2e.yml
+++ b/.github/workflows/test-prod-e2e.yml
@@ -50,7 +50,7 @@ jobs:
           pin_status=""
 
           while [[ "$pin_status" != "Pinned" ]]; do
-            response=$(curl --oauth2-bearer "$W3STORAGE_TOKEN" "https://api.web3.storage/status/$cid")
+            response=$(curl --oauth2-bearer "$W3STORAGE_TOKEN" "https://api.web3.storage/status/$CID")
             pin_status=$(echo $response | jq -r '.pins[0].status')
             echo "Current pin status: $pin_status"
 

--- a/.github/workflows/test-prod-e2e.yml
+++ b/.github/workflows/test-prod-e2e.yml
@@ -70,6 +70,7 @@ jobs:
     strategy:
       matrix:
         target: ["ipfs.runfission.com", "w3s.link"]
+      fail-fast: false
     defaults:
       run:
         shell: bash
@@ -115,16 +116,40 @@ jobs:
       run:
         shell: bash
     steps:
+      - uses: actions/checkout@v3
+        with:
+          path: "gateway-conformance"
       - name: Download Artifacts
         uses: actions/download-artifact@v3
         with:
           path: artifacts
       - name: Aggregate results
+        working-directory: ./artifacts
         run: |
           set -e
           set -o pipefail
+          mkdir aggregates/
 
-          echo $PWD
           ls ./
-          ls ./*.json
-        working-directory: ./artifacts
+          ls ./*
+          ls ./*/*
+
+          # download-artifact downloads artifacts in a directory named after the artifact
+          # details: https://github.com/actions/download-artifact#download-all-artifacts
+          for folder in ./conformance-*.json; do
+            echo $folder;
+            file="${folder}/output.json"
+            new_file="aggregates/${folder#conformance-}"
+            jq -ns 'inputs' "$file" | node ../gateway-conformance/aggregate.js 1 > "${new_file}"
+          done
+
+          node ../gateway-conformance/aggregate-into-table.js ./aggregates/*.json > ./table.md
+      - name: Set summary
+        if: (failure() || success())
+        run: cat ./artifacts/table.md >> $GITHUB_STEP_SUMMARY
+      - name: Upload one-page MD report
+        if: (failure() || success())
+        uses: actions/upload-artifact@v3
+        with:
+          name: conformance.md
+          path: ./table.md

--- a/.github/workflows/test-prod-e2e.yml
+++ b/.github/workflows/test-prod-e2e.yml
@@ -139,9 +139,3 @@ jobs:
       - name: Set summary
         if: (failure() || success())
         run: cat ./artifacts/table.md >> $GITHUB_STEP_SUMMARY
-      - name: Upload one-page MD report
-        if: (failure() || success())
-        uses: actions/upload-artifact@v3
-        with:
-          name: conformance.md
-          path: ./table.md

--- a/.github/workflows/test-prod-e2e.yml
+++ b/.github/workflows/test-prod-e2e.yml
@@ -1,4 +1,4 @@
-name: Test Kubo (e2e)
+name: Test Production (e2e)
 
 on:
   workflow_dispatch:

--- a/.github/workflows/test-prod-e2e.yml
+++ b/.github/workflows/test-prod-e2e.yml
@@ -63,7 +63,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        target: ["ipfs.runfission.com"]
+        target: ["ipfs.runfission.com", "w3s.link"]
     defaults:
       run:
         shell: bash

--- a/.github/workflows/test-prod-e2e.yml
+++ b/.github/workflows/test-prod-e2e.yml
@@ -99,5 +99,5 @@ jobs:
         if: (failure() || success())
         uses: actions/upload-artifact@v3
         with:
-          name: conformance.html
+          name: conformance-${{ matrix.target }}.html
           path: ./output.html

--- a/.github/workflows/test-prod-e2e.yml
+++ b/.github/workflows/test-prod-e2e.yml
@@ -92,9 +92,6 @@ jobs:
           xml: output.xml
           html: output.html
           markdown: output.md
-      - name: Set summary
-        if: (failure() || success())
-        run: cat ./output.md >> $GITHUB_STEP_SUMMARY
       - name: Upload one-page HTML report
         if: (failure() || success())
         uses: actions/upload-artifact@v3
@@ -128,16 +125,11 @@ jobs:
         run: |
           set -e
           set -o pipefail
-          mkdir aggregates/
-
-          ls ./
-          ls ./*
-          ls ./*/*
+          mkdir ./aggregates
 
           # download-artifact downloads artifacts in a directory named after the artifact
           # details: https://github.com/actions/download-artifact#download-all-artifacts
           for folder in ./conformance-*.json; do
-            echo $folder;
             file="${folder}/output.json"
             new_file="aggregates/${folder#conformance-}"
             jq -ns 'inputs' "$file" | node ../gateway-conformance/aggregate.js 1 > "${new_file}"

--- a/.github/workflows/test-prod-e2e.yml
+++ b/.github/workflows/test-prod-e2e.yml
@@ -31,7 +31,7 @@ jobs:
         env: 
           W3STORAGE_TOKEN: ${{ secrets.W3STORAGE_TOKEN }}
         run: |
-          curl --headers "Authorization: Bearer $W3STORAGE_TOKEN" --data-binary @fixtures.car
+          curl --oauth2-bearer "$W3STORAGE_TOKEN" --data-binary @fixtures.car
   test:
     runs-on: 'ubuntu-latest'
     strategy:

--- a/.github/workflows/test-prod-e2e.yml
+++ b/.github/workflows/test-prod-e2e.yml
@@ -32,25 +32,25 @@ jobs:
         env:
           W3STORAGE_TOKEN: ${{ secrets.W3STORAGE_TOKEN }}
         run: |
-          response=$(curl --oauth2-bearer "$W3STORAGE_TOKEN" --data-binary @fixtures.car "https://api.web3.storage/car")
-          status=$?
+          set -e
+          set -o pipefail
 
-          if [ $status -eq 0 ]; then
-            cid=$(echo $response | jq -r .cid)
-            echo "Pinned fixtures to w3.storage with CID: $cid"
-            echo "cid=$cid" >> "$GITHUB_OUTPUT"
-          else
-            exit $status
-          fi
+          response=$(curl --fail --oauth2-bearer "$W3STORAGE_TOKEN" --data-binary @fixtures.car "https://api.web3.storage/car")
+          cid=$(echo $response | jq -r .cid)
+          echo "Pinned fixtures to w3.storage with CID: $cid"
+          echo "cid=$cid" >> "$GITHUB_OUTPUT"
       - name: Wait for pinning
         env:
           W3STORAGE_TOKEN: ${{ secrets.W3STORAGE_TOKEN }}
           CID: ${{ steps.upload.outputs.cid }}
         run: |
+          set -e
+          set -o pipefail
+
           pin_status=""
 
           while [[ "$pin_status" != "Pinned" ]]; do
-            response=$(curl --oauth2-bearer "$W3STORAGE_TOKEN" "https://api.web3.storage/status/$CID")
+            response=$(curl --fail --oauth2-bearer "$W3STORAGE_TOKEN" "https://api.web3.storage/status/$CID")
             pin_status=$(echo $response | jq -r '.pins[0].status')
             echo "Current pin status: $pin_status"
 

--- a/.github/workflows/test-prod-e2e.yml
+++ b/.github/workflows/test-prod-e2e.yml
@@ -124,5 +124,7 @@ jobs:
           set -e
           set -o pipefail
 
-          ls ./artifacts
+          echo $PWD
+          ls ./
+          ls ./*.json
         working-directory: ./artifacts

--- a/.github/workflows/test-prod-e2e.yml
+++ b/.github/workflows/test-prod-e2e.yml
@@ -3,13 +3,13 @@ name: Test Kubo (e2e)
 on:
   workflow_dispatch:
   push:
-    branches: 
+    branches:
       - main
   pull_request:
 
 jobs:
   upload-fixtures:
-    runs-on: 'ubuntu-latest'
+    runs-on: "ubuntu-latest"
     defaults:
       run:
         shell: bash
@@ -20,7 +20,7 @@ jobs:
           go-version: 1.20.4
       - uses: actions/checkout@v3
         with:
-          path: 'gateway-conformance'
+          path: "gateway-conformance"
       - name: Extract fixtures
         uses: ./gateway-conformance/.github/actions/extract-fixtures
         with:
@@ -28,12 +28,38 @@ jobs:
           merged: true
       # https://web3.storage/docs/how-tos/store/#storing-ipfs-content-archives
       - name: Upload fixtures
-        env: 
+        id: upload
+        env:
           W3STORAGE_TOKEN: ${{ secrets.W3STORAGE_TOKEN }}
         run: |
-          curl --oauth2-bearer "$W3STORAGE_TOKEN" --data-binary @fixtures.car
+          response=$(curl --oauth2-bearer "$W3STORAGE_TOKEN" --data-binary @fixtures.car "https://api.web3.storage/car")
+          status=$?
+
+          if [ $status -eq 0 ]; then
+            cid=$(echo $response | jq -r .cid)
+            echo "Pinned fixtures to w3.storage with CID: $cid"
+            echo "cid=$cid" >> "$GITHUB_OUTPUT"
+          else
+            exit $status
+          fi
+      - name: Wait for pinning
+        env:
+          W3STORAGE_TOKEN: ${{ secrets.W3STORAGE_TOKEN }}
+          CID: ${{ steps.upload.outputs.cid }}
+        run: |
+          pin_status=""
+
+          while [[ "$pin_status" != "Pinned" ]]; do
+            response=$(curl --oauth2-bearer "$W3STORAGE_TOKEN" "https://api.web3.storage/status/$cid")
+            pin_status=$(echo $response | jq -r '.pins[0].status')
+            echo "Current pin status: $pin_status"
+
+            if [[ "$pin_status" != "Pinned" ]]; then
+              sleep 10 # Sleep for 10 seconds before trying again
+            fi
+          done
   test:
-    runs-on: 'ubuntu-latest'
+    runs-on: "ubuntu-latest"
     strategy:
       fail-fast: false
       matrix:
@@ -49,7 +75,7 @@ jobs:
           go-version: 1.20.4
       - uses: actions/checkout@v3
         with:
-          path: 'gateway-conformance'
+          path: "gateway-conformance"
       - name: Run the tests
         uses: ./gateway-conformance/.github/actions/test
         with:

--- a/.github/workflows/test-prod-e2e.yml
+++ b/.github/workflows/test-prod-e2e.yml
@@ -101,3 +101,29 @@ jobs:
         with:
           name: conformance-${{ matrix.target }}.html
           path: ./output.html
+      - name: Upload JSON output
+        if: (failure() || success())
+        uses: actions/upload-artifact@v3
+        with:
+          name: conformance-${{ matrix.target }}.json
+          path: ./output.json
+  aggregate:
+    runs-on: "ubuntu-latest"
+    needs: [test]
+    strategy:
+      fail-fast: true
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - name: Download Artifacts
+        uses: actions/download-artifact@v3
+        with:
+          path: artifacts
+      - name: Aggregate results
+        run: |
+          set -e
+          set -o pipefail
+
+          ls ./artifacts
+        working-directory: ./artifacts

--- a/.github/workflows/test-prod-e2e.yml
+++ b/.github/workflows/test-prod-e2e.yml
@@ -1,0 +1,70 @@
+name: Test Kubo (e2e)
+
+on:
+  workflow_dispatch:
+  push:
+    branches: 
+      - main
+  pull_request:
+
+jobs:
+  upload-fixtures:
+    runs-on: 'ubuntu-latest'
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - name: Setup Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: 1.20.4
+      - uses: actions/checkout@v3
+        with:
+          path: 'gateway-conformance'
+      - name: Extract fixtures
+        uses: ./gateway-conformance/.github/actions/extract-fixtures
+        with:
+          output: ./
+          merged: true
+      # https://web3.storage/docs/how-tos/store/#storing-ipfs-content-archives
+      - name: Upload fixtures
+        env: 
+          W3STORAGE_TOKEN: ${{ secrets.W3STORAGE_TOKEN }}
+        run: |
+          curl --headers "Authorization: Bearer $W3STORAGE_TOKEN" --data-binary @fixtures.car
+  test:
+    runs-on: 'ubuntu-latest'
+    strategy:
+      fail-fast: false
+      matrix:
+        target: ["ipfs.runfission.com"]
+    defaults:
+      run:
+        shell: bash
+    needs: upload-fixtures
+    steps:
+      - name: Setup Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: 1.20.4
+      - uses: actions/checkout@v3
+        with:
+          path: 'gateway-conformance'
+      - name: Run the tests
+        uses: ./gateway-conformance/.github/actions/test
+        with:
+          gateway-url: https://${{ matrix.target }}
+          subdomain-url: https://${{ matrix.target }}
+          json: output.json
+          xml: output.xml
+          html: output.html
+          markdown: output.md
+      - name: Set summary
+        if: (failure() || success())
+        run: cat ./output.md >> $GITHUB_STEP_SUMMARY
+      - name: Upload one-page HTML report
+        if: (failure() || success())
+        uses: actions/upload-artifact@v3
+        with:
+          name: conformance.html
+          path: ./output.html

--- a/.github/workflows/test-prod-e2e.yml
+++ b/.github/workflows/test-prod-e2e.yml
@@ -34,31 +34,9 @@ jobs:
           web3_token: ${{ secrets.W3STORAGE_TOKEN }}
           path_to_add: 'fixtures.car'
       - name: Wait for pinning
-        env:
-          W3STORAGE_TOKEN: ${{ secrets.W3STORAGE_TOKEN }}
-          CID: ${{ steps.upload.outputs.cid }}
         run: |
-          set -e
-          set -o pipefail
-
-          pin_status=""
-          start_time=$(date +%s)
-          timeout=$((2 * 60)) # Timeout set to 2 minutes
-
-          while [[ "$pin_status" != "Pinned" ]]; do
-            response=$(curl --fail --oauth2-bearer "$W3STORAGE_TOKEN" "https://api.web3.storage/status/$CID")
-            pin_status=$(echo $response | jq -r '.pins[0].status')
-            echo "Current pin status: $pin_status"
-
-            current_time=$(date +%s)
-            elapsed_time=$((current_time - start_time))
-
-            if [[ "$pin_status" != "Pinned" && $elapsed_time -lt $timeout ]]; then
-              sleep 10 # Sleep for 10 seconds before trying again
-            else
-              break
-            fi
-          done
+          sleep 180 # 3 minutes
+          # see rational in https://github.com/ipfs/gateway-conformance/pull/108#discussion_r1274628865
   test:
     runs-on: "ubuntu-latest"
     strategy:

--- a/.github/workflows/test-prod-e2e.yml
+++ b/.github/workflows/test-prod-e2e.yml
@@ -29,16 +29,10 @@ jobs:
       # https://web3.storage/docs/how-tos/store/#storing-ipfs-content-archives
       - name: Upload fixtures
         id: upload
-        env:
-          W3STORAGE_TOKEN: ${{ secrets.W3STORAGE_TOKEN }}
-        run: |
-          set -e
-          set -o pipefail
-
-          response=$(curl --fail --oauth2-bearer "$W3STORAGE_TOKEN" --data-binary @fixtures.car "https://api.web3.storage/car")
-          cid=$(echo $response | jq -r .cid)
-          echo "Pinned fixtures to w3.storage with CID: $cid"
-          echo "cid=$cid" >> "$GITHUB_OUTPUT"
+        uses: web3-storage/add-to-web3@v2
+        with:
+          web3_token: ${{ secrets.W3STORAGE_TOKEN }}
+          path_to_add: 'fixtures.car'
       - name: Wait for pinning
         env:
           W3STORAGE_TOKEN: ${{ secrets.W3STORAGE_TOKEN }}

--- a/.github/workflows/test-prod-e2e.yml
+++ b/.github/workflows/test-prod-e2e.yml
@@ -7,6 +7,10 @@ on:
       - main
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event_name == 'push' && github.sha || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   upload-fixtures:
     runs-on: "ubuntu-latest"

--- a/.github/workflows/test-prod-e2e.yml
+++ b/.github/workflows/test-prod-e2e.yml
@@ -95,8 +95,6 @@ jobs:
       - name: Aggregate results
         working-directory: ./artifacts
         run: |
-          set -e
-          set -o pipefail
           mkdir ./aggregates
 
           # download-artifact downloads artifacts in a directory named after the artifact

--- a/.github/workflows/update-badge.yml
+++ b/.github/workflows/update-badge.yml
@@ -7,10 +7,9 @@ on:
       - Test Production (e2e)
     types:
       - completed
-      - completed-with-failure
-    branches:
-      - main
-      - feat/text-production-gateways # temporary
+    # branches:
+    #   - main
+    #   - feat/text-production-gateways # temporary
 
 defaults:
   run:

--- a/.github/workflows/update-badge.yml
+++ b/.github/workflows/update-badge.yml
@@ -1,0 +1,57 @@
+# based on https://github.com/libp2p/test-plans/pull/86
+name: Update Badge
+
+on:
+  workflow_run:
+    workflows:
+      - Test Production (e2e)
+    types:
+      - completed
+    branches:
+      - main
+      - feat/text-production-gateways # temporary
+
+defaults:
+  run:
+    shell: bash
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
+
+jobs:
+  update-badge:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: pl-strflt/job-summary-url-action@v1
+        name: get-metadata
+        with:
+          workflow: test-prod-e2e.yml # ${{ github.event.workflow.path }}
+          run_id: ${{ github.event.workflow_run.id }}
+          run_attempt: ${{ github.event.workflow_run.run_attempt }}
+          job: aggregate
+      - uses: actions/checkout@v3
+      # https://github.com/orgs/community/discussions/26560
+      - run: |
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config user.name "github-actions[bot]"
+      - run: |
+          GITHUB_JOB_SUMMARY_URL="${{ steps.get-metadata.outputs.job_summary_url }}"
+
+          IN='[![Conformance Production Dashboard](https://github.com/ipfs/gateway-conformance/actions/workflows/test-prod-e2e.yml/badge.svg?branch=master)](.*)'
+          ESCAPED_IN=$(printf '%s\n' "$IN" | sed -e 's/[][\/!&]/\\&/g')
+
+          OUT="[![Conformance Production Dashboard](https://github.com/ipfs/gateway-conformance/actions/workflows/test-prod-e2e.yml/badge.svg?branch=master)](${GITHUB_JOB_SUMMARY_URL})"
+
+          sed -i "s;${ESCAPED_IN};${OUT};" README.md
+      - run: |
+          if [[ -n $(git diff --shortstat 2> /dev/null | tail -n1) ]]; then
+            echo "GIT_DIRTY=1" >> $GITHUB_ENV
+          else
+            echo "GIT_DIRTY=0" >> $GITHUB_ENV
+          fi
+      - if: env.GIT_DIRTY == '1'
+        run: |
+          git add README.md
+          git commit -m 'chore: update the link to the dashboard [skip ci]'
+          git push

--- a/.github/workflows/update-badge.yml
+++ b/.github/workflows/update-badge.yml
@@ -1,3 +1,5 @@
+# Note: this workflow requires the repository to give Write access to Github Workflows.
+# in Settings > Actions > General > Workflow permissions
 name: Update Badge
 
 on:
@@ -6,9 +8,8 @@ on:
       - Test Production (e2e)
     types:
       - completed
-    # branches:
-    #   - main
-    #   - feat/text-production-gateways # temporary
+    branches:
+      - main
 
 defaults:
   run:
@@ -23,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: pl-strflt/job-summary-url-action@v1
-        name: metadata
+        id: metadata
         with:
           workflow: test-prod-e2e.yml # ${{ github.event.workflow.path }}
           run_id: ${{ github.event.workflow_run.id }}
@@ -35,14 +36,16 @@ jobs:
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git config user.name "github-actions[bot]"
       - run: |
-          GITHUB_JOB_SUMMARY_URL="${{ steps.metadata.outputs.job_summary_url }}"
-
+          echo GITHUB_JOB_SUMMARY_URL=${GITHUB_JOB_SUMMARY_URL}
           IN='[![Conformance Production Dashboard](https://github.com/ipfs/gateway-conformance/actions/workflows/test-prod-e2e.yml/badge.svg?branch=master)](.*)'
           ESCAPED_IN=$(printf '%s\n' "$IN" | sed -e 's/[][\/!&]/\\&/g')
 
           OUT="[![Conformance Production Dashboard](https://github.com/ipfs/gateway-conformance/actions/workflows/test-prod-e2e.yml/badge.svg?branch=master)](${GITHUB_JOB_SUMMARY_URL})"
 
           sed -i "s;${ESCAPED_IN};${OUT};" README.md
+        env:
+          GITHUB_JOB_SUMMARY_URL: ${{ steps.metadata.outputs.job_summary_url }}
+          REPOSITORY: ${{ github.repository }}
       - run: |
           if [[ -n $(git diff --shortstat 2> /dev/null | tail -n1) ]]; then
             echo "GIT_DIRTY=1" >> $GITHUB_ENV

--- a/.github/workflows/update-badge.yml
+++ b/.github/workflows/update-badge.yml
@@ -1,7 +1,6 @@
 name: Update Badge
 
 on:
-  pull_request:
   workflow_run:
     workflows:
       - Test Production (e2e)

--- a/.github/workflows/update-badge.yml
+++ b/.github/workflows/update-badge.yml
@@ -1,7 +1,7 @@
-# based on https://github.com/libp2p/test-plans/pull/86
 name: Update Badge
 
 on:
+  pull_request:
   workflow_run:
     workflows:
       - Test Production (e2e)
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: pl-strflt/job-summary-url-action@v1
-        name: get-metadata
+        name: metadata
         with:
           workflow: test-prod-e2e.yml # ${{ github.event.workflow.path }}
           run_id: ${{ github.event.workflow_run.id }}
@@ -36,7 +36,7 @@ jobs:
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git config user.name "github-actions[bot]"
       - run: |
-          GITHUB_JOB_SUMMARY_URL="${{ steps.get-metadata.outputs.job_summary_url }}"
+          GITHUB_JOB_SUMMARY_URL="${{ steps.metadata.outputs.job_summary_url }}"
 
           IN='[![Conformance Production Dashboard](https://github.com/ipfs/gateway-conformance/actions/workflows/test-prod-e2e.yml/badge.svg?branch=master)](.*)'
           ESCAPED_IN=$(printf '%s\n' "$IN" | sed -e 's/[][\/!&]/\\&/g')

--- a/.github/workflows/update-badge.yml
+++ b/.github/workflows/update-badge.yml
@@ -7,6 +7,7 @@ on:
       - Test Production (e2e)
     types:
       - completed
+      - completed-with-failure
     branches:
       - main
       - feat/text-production-gateways # temporary

--- a/.github/workflows/update-badge.yml
+++ b/.github/workflows/update-badge.yml
@@ -1,5 +1,8 @@
 # Note: this workflow requires the repository to give Write access to Github Workflows.
 # in Settings > Actions > General > Workflow permissions
+
+permissions:
+  contents: write
 name: Update Badge
 
 on:

--- a/.github/workflows/update-badge.yml
+++ b/.github/workflows/update-badge.yml
@@ -49,13 +49,14 @@ jobs:
         env:
           GITHUB_JOB_SUMMARY_URL: ${{ steps.metadata.outputs.job_summary_url }}
           REPOSITORY: ${{ github.repository }}
-      - run: |
+      - id: git
+         run: |
           if [[ -n $(git diff --shortstat 2> /dev/null | tail -n1) ]]; then
-            echo "GIT_DIRTY=1" >> $GITHUB_ENV
+            echo "dirty=1" >> $GITHUB_OUTPUT
           else
-            echo "GIT_DIRTY=0" >> $GITHUB_ENV
+            echo "dirty=0" >> $GITHUB_OUTPUT
           fi
-      - if: env.GIT_DIRTY == '1'
+      - if: steps.git.outputs.dirty == '1'
         run: |
           git add README.md
           git commit -m 'chore: update the link to the dashboard [skip ci]'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - finalized port of Kubo's sharness tests. [PR](https://github.com/ipfs/gateway-conformance/pull/92)
+- `extract-fixtures --merged` generates a car version 1 with a single root now
 
 ## [0.2.0] - 2023-06-26
 ### Added

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 `gateway-conformance` is a tool designed to test if an IPFS Gateway implementation complies with the IPFS Gateway Specification correctly. The tool is distributed as a Docker image, as well as a GitHub Action(s).
 
-[![Conformance Production Dashboard](https://github.com/ipfs/gateway-conformance/actions/workflows/test-prod-e2e.yml/badge.svg?branch=master)](something-something)
+[![Conformance Production Dashboard](https://github.com/ipfs/gateway-conformance/actions/workflows/test-prod-e2e.yml/badge.svg?branch=master)]()
 
 ## Table of Contents
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 `gateway-conformance` is a tool designed to test if an IPFS Gateway implementation complies with the IPFS Gateway Specification correctly. The tool is distributed as a Docker image, as well as a GitHub Action(s).
 
+[![Conformance Production Dashboard](https://github.com/ipfs/gateway-conformance/actions/workflows/test-prod-e2e.yml/badge.svg?branch=master)](something-something)
+
 ## Table of Contents
 
 - [Commands](#commands)

--- a/aggregate-into-table.js
+++ b/aggregate-into-table.js
@@ -1,0 +1,86 @@
+const fs = require("fs");
+
+// retrieve the list of input files from the command line
+const files = process.argv.slice(2);
+
+// read all input files (json)
+const inputs = files.map((file) => {
+    return JSON.parse(fs.readFileSync(file, 'utf8'));
+}
+);
+
+// merge all the unique keys from all the inputs
+let keys = new Set();
+inputs.forEach((input) => {
+    Object.keys(input).forEach((key) => {
+        keys.add(key);
+    });
+});
+keys = Array.from(keys).sort();
+
+// generate a table
+const columns = [];
+
+// add the leading column ("gateway", "key1", "key2", ... "keyN")
+const leading = ["gateway"];
+keys.forEach((key) => {
+    // Skip the "Test" prefix
+    const niceKey = key.replace(/^Test/, '');
+    leading.push(niceKey);
+});
+columns.push(leading);
+
+// add the data for every input
+const cellRender = (cell) => {
+    if (cell === null) {
+        return '';
+    }
+
+    if (cell['fail'] > 0) {
+        return `:red_circle: (${cell['pass']} / ${cell['total']})`;
+    }
+    if (cell['skip'] > 0) {
+        return `:yellow_circle: (skipped)`;
+    }
+    if (cell['pass'] > 0) {
+        return `:green_circle: (${cell['pass']} / ${cell['total']})`;
+    }
+
+    throw new Error(`Unhandled cell value: ${JSON.stringify(cell)}`);
+}
+
+inputs.forEach((input, index) => {
+    // clean name (remove path and extension)
+    let name = files[index].replace(/\.json$/, '').replace(/^.*\//, '');
+
+    const col = [name];
+    keys.forEach((key) => {
+        col.push(cellRender(input[key] || null));
+    });
+    columns.push(col);
+});
+
+// # Rotate the table
+// it's easier to create the table by column, but we want to render it by row
+let rows = columns[0].map((_, i) => columns.map(col => col[i]));
+
+// # Render the table into a markdown table
+
+// add the hyphen header row after the first row
+const hyphenated = rows[0].map((x, i) => {
+    if (i === 0) {
+        return '-'.repeat(Math.max(0, x.length - 2)) + '-:'
+    }
+    return ':-' + '-'.repeat(Math.max(0, x.length - 2));
+})
+
+rows = [
+    rows[0],
+    hyphenated,
+    ...rows.slice(1),
+]
+
+let markdown = rows.map(row => '| ' + row.join(' | ') + ' |').join('\n');
+
+// output the table to stdout
+fs.writeFileSync(1, markdown);

--- a/aggregate.js
+++ b/aggregate.js
@@ -1,0 +1,94 @@
+const fs = require("fs");
+
+// # read json from stdin:
+let lines = fs.readFileSync(0, "utf-8");
+lines = JSON.parse(lines);
+
+// # clean input
+lines = lines.filter((line) => {
+  const { Test } = line;
+  return Test !== undefined;
+});
+
+lines = lines.filter((line) => {
+  const { Action } = line;
+  return ["pass", "fail", "skip"].includes(Action);
+});
+
+// # add "Path" field by parsing "Name" and split by "/"
+//   also update the name to make it readable
+//   also remove "Time" field while we're at it
+lines = lines.map((line) => {
+  const { Test, Time, ...rest } = line;
+  const path = Test.split("/").map((name) => {
+    return name.replace(/_/g, " ");
+  });
+
+  return { ...rest, Path: path };
+});
+
+// # Aggregate all known "Path" values, use a tree structure to represent it
+//   {
+//       child1: {
+//           child2: {
+//               ...,
+//           }
+//       }
+//   }
+const testTree = {};
+
+lines.forEach((line) => {
+  const { Path } = line;
+  let current = testTree;
+
+  Path.forEach((path) => {
+    if (!current[path]) {
+      current[path] = {};
+    }
+    current = current[path];
+  });
+})
+
+// # Drop all lines where the Test "Path" does not point to a leaf
+//   if the test has children then we don't really care about it's pass / fail / skip status,
+//   we'll aggregate its children results'
+lines = lines.filter((line) => {
+  const { Path } = line;
+  let current = testTree;
+
+  Path.forEach((path) => {
+    if (!current[path]) {
+      return false;
+    }
+    current = current[path];
+  });
+
+  // if current has children, it is not a leaf
+  return Object.keys(current).length === 0;
+});
+
+// # Aggregate by Path and count actions
+
+const depth = process.argv[2] && parseInt(process.argv[2], 10) || 1;
+
+// test result is a map { [path_str]: { [path], [action]: count } }
+const testResults = {};
+
+lines.forEach((line) => {
+  const { Path, Action } = line;
+  let current = testResults;
+
+  const path = Path.slice(0, depth)
+  const key = path.join(" > ");
+
+  if (!current[key]) {
+    current[key] = {Path: path, "pass": 0, "fail": 0, "skip": 0, "total": 0};
+  }
+  current = current[key];
+
+  current[Action] += 1;
+  current["total"] += 1;
+});
+
+// output result to stdout
+fs.writeFileSync(1, JSON.stringify(testResults, null, 2));

--- a/go.mod
+++ b/go.mod
@@ -47,7 +47,7 @@ require (
 	github.com/hashicorp/golang-lru v0.5.4 // indirect
 	github.com/ipfs/bbloom v0.0.4 // indirect
 	github.com/ipfs/go-bitfield v1.1.0 // indirect
-	github.com/ipfs/go-block-format v0.1.2 // indirect
+	github.com/ipfs/go-block-format v0.1.2
 	github.com/ipfs/go-datastore v0.6.0 // indirect
 	github.com/ipfs/go-ipfs-util v0.0.2 // indirect
 	github.com/ipfs/go-ipld-cbor v0.0.6 // indirect

--- a/tooling/car/merge.go
+++ b/tooling/car/merge.go
@@ -7,6 +7,11 @@ import (
 	"github.com/ipfs/go-cid"
 	carv2 "github.com/ipld/go-car/v2"
 	"github.com/ipld/go-car/v2/blockstore"
+	"github.com/ipld/go-ipld-prime/fluent"
+	"github.com/ipld/go-ipld-prime/linking"
+	cidlink "github.com/ipld/go-ipld-prime/linking/cid"
+	basicnode "github.com/ipld/go-ipld-prime/node/basic"
+	"github.com/ipld/go-ipld-prime/storage/memstore"
 )
 
 func Merge(inputPaths []string, outputPath string) error {
@@ -30,18 +35,55 @@ func Merge(inputPaths []string, outputPath string) error {
 		roots = append(roots, r...)
 	}
 
-	// Now prepare our new CAR file
-	fmt.Printf("Opening the %s file, with roots: %v\n", outputPath, roots)
-	options := []carv2.Option{blockstore.WriteAsCarV1(true)}
-	rout, err := blockstore.OpenReadWrite(outputPath, roots[0:1], options...)
+	// Then aggregate all roots under a single one
+	lsys := cidlink.DefaultLinkSystem()
+	store := memstore.Store{Bag: make(map[string][]byte)}
+	lsys.SetWriteStorage(&store)
+	lsys.SetReadStorage(&store)
+
+	node := fluent.MustBuildList(basicnode.Prototype.List, int64(len(roots)), func(na fluent.ListAssembler) {
+		for _, root := range roots {
+			na.AssembleValue().AssignLink(cidlink.Link{Cid: root})
+		}
+	})
+
+	lp := cidlink.LinkPrototype{Prefix: cid.Prefix{
+		Version:  1,    // Usually '1'.
+		Codec:    0x71, // 0x71 means "dag-cbor" -- See the multicodecs table: https://github.com/multiformats/multicodec/
+		MhType:   0x13, // 0x20 means "sha2-512" -- See the multicodecs table: https://github.com/multiformats/multicodec/
+		MhLength: 64,   // sha2-512 hash has a 64-byte sum.
+	}}
+
+	lnk, err := lsys.Store(
+		linking.LinkContext{},
+		lp,
+		node)
 	if err != nil {
 		return err
 	}
 
+	rootCid := lnk.(cidlink.Link).Cid
+
+	fmt.Printf("Root CID: %s\n", rootCid.String())
+
+	// Now prepare our new CAR file
+	fmt.Printf("Opening the %s file, with roots: %v\n", outputPath, roots)
+	options := []carv2.Option{blockstore.WriteAsCarV1(true)}
+	rout, err := blockstore.OpenReadWrite(outputPath, []cid.Cid{rootCid}, options...)
+	if err != nil {
+		return err
+	}
+
+	// Add blocks from our store (root block)
+	// TODO: how to?
+	// for every block in our store, add it to `rout`
+	// for ever k, v in store.Bag ????
+
 	// Then aggregate all our blocks.
 	for _, path := range inputPaths {
 		fmt.Printf("processing %s\n", path)
-		robs, err := blockstore.OpenReadOnly(path,
+		robs, err := blockstore.OpenReadOnly(
+			path,
 			blockstore.UseWholeCIDs(true),
 		)
 		if err != nil {

--- a/tooling/car/merge.go
+++ b/tooling/car/merge.go
@@ -28,9 +28,8 @@ func cidFromBinString(key string) (cid.Cid, error) {
 }
 
 func Merge(inputPaths []string, outputPath string) error {
-	// First list all the roots in our fixtures
-	roots := make([]cid.Cid, 0)
-
+	// First list all the unique roots in our fixtures
+	uniqRoots := make(map[string]cid.Cid)
 	for _, path := range inputPaths {
 		fmt.Printf("processing %s\n", path)
 		robs, err := blockstore.OpenReadOnly(path,
@@ -45,7 +44,14 @@ func Merge(inputPaths []string, outputPath string) error {
 			return err
 		}
 
-		roots = append(roots, r...)
+		for _, root := range r {
+			uniqRoots[root.String()] = root
+		}
+	}
+
+	roots := make([]cid.Cid, 0)
+	for _, root := range uniqRoots {
+		roots = append(roots, root)
 	}
 
 	// Then aggregate all roots under a single one
@@ -54,68 +60,16 @@ func Merge(inputPaths []string, outputPath string) error {
 	lsys.SetWriteStorage(&store)
 	lsys.SetReadStorage(&store)
 
-	// THIS was not compatible with dag pb I think,
-	// node := fluent.MustBuildList(basicnode.Prototype.List, int64(len(roots)), func(na fluent.ListAssembler) {
-	// 	for _, root := range roots {
-	// 		na.AssembleValue().AssignLink(cidlink.Link{Cid: root})
-	// 	}
-	// })
-
-	// creating list of uniq roots
-	uniqRoots := make(map[string]cid.Cid)
-	for _, root := range roots {
-		uniqRoots[root.String()] = root
-	}
-	roots = make([]cid.Cid, 0)
-	for _, root := range uniqRoots {
-		roots = append(roots, root)
-	}
-
-	// Adding to a map, they won't accept duplicate, hence the code above
+	// Adding to a map, they won't accept duplicate, hence the need for the uniqRoots
 	node := fluent.MustBuildMap(basicnode.Prototype.Map, int64(len(roots)), func(ma fluent.MapAssembler) {
 		ma.AssembleEntry("Links").CreateList(int64(len(roots)), func(na fluent.ListAssembler) {
 			for _, root := range roots {
 				na.AssembleValue().CreateMap(3, func(fma fluent.MapAssembler) {
-					// fma.AssembleEntry("Name").AssignString("")
-					// fma.AssembleEntry("Tsize").AssignInt(262158)
 					fma.AssembleEntry("Hash").AssignLink(cidlink.Link{Cid: root})
 				})
-
 			}
 		})
-
-		// this code gives:
-		// 2023/07/05 11:13:54 invalid key for map dagpb.PBNode: "bafybeicaj7kvxpcv4neaqzwhrqqmdstu4dhrwfpknrgebq6nzcecfucvyu": no such field
-		// for _, root := range roots {
-		// 	fmt.Println("adding root", root)
-		// 	ma.AssembleEntry(root.String()).AssignLink(cidlink.Link{Cid: root})
-		// }
 	})
-
-	// NOTE: by default we generate super large CIDs (from the doc)
-	// which are not compatible with dns.
-	// lp := cidlink.LinkPrototype{Prefix: cid.Prefix{
-	// 	Version:  1,    // Usually '1'.
-	// 	Codec:    0x71, // 0x71 means "dag-cbor" -- See the multicodecs table: https://github.com/multiformats/multicodec/
-	// 	MhType:   0x13, // 0x20 means "sha2-512" -- See the multicodecs table: https://github.com/multiformats/multicodec/
-	// 	MhLength: 64,   // sha2-512 hash has a 64-byte sum.
-	// }}
-	// cid: bafyrgqhpkthtuhnrvrnzobebylknmj4ayxac2f3kfm7pxm5ywmhu65ztzuyz4mmrhwf4sjliwntozivctgwk6qxiquospjybg37o4aiyvzt64
-	// So I switch to sah2-256:
-
-	// lp := cidlink.LinkPrototype{Prefix: cid.Prefix{
-	// 	Version:  1,
-	// 	Codec:    0x71,
-	// 	MhType:   0x12,  // sha2-256
-	// 	MhLength: 32,
-	// }}
-	// Trying to publish that configuratino:
-	/*
-		curl --oauth2-bearer "$W3STORAGE_TOKEN" --data-binary @fixtures.car "https://api.web3.storage/car"
-		{"code":"HTTP_ERROR","message":"protobuf: (PBNode) invalid wireType, expected 2, got 0"}%
-
-		What is that wireType? Maybe we can only publish dag-pb, so let's try.
-	*/
 
 	lp := cidlink.LinkPrototype{Prefix: cid.Prefix{
 		Version:  1,
@@ -123,53 +77,33 @@ func Merge(inputPaths []string, outputPath string) error {
 		MhType:   0x12,
 		MhLength: 32, // sha2-256
 	}}
-	/**
-	Trying to run with that code, no the code doesn't complete:
-	2023/07/05 10:57:36 func called on wrong kind: "AssignNode" called on a dagpb.PBNode node (kind: list), but only makes sense on map
-	*/
 
 	lnk, err := lsys.Store(
 		linking.LinkContext{},
 		lp,
 		node)
-
 	if err != nil {
 		return err
 	}
 
 	rootCid := lnk.(cidlink.Link).Cid
-	fmt.Printf("Root CID: %s\n", rootCid.String())
 
 	// Now prepare our new CAR file
-	fmt.Printf("Opening the %s file, with roots: %v\n", outputPath, roots)
+	fmt.Printf("Opening the %s file, with root: %v\n", outputPath, rootCid)
 	options := []carv2.Option{blockstore.WriteAsCarV1(true)}
 	rout, err := blockstore.OpenReadWrite(outputPath, []cid.Cid{rootCid}, options...)
 	if err != nil {
-		fmt.Println("Error here0:", err)
+		fmt.Println("Error here:a", err)
 		return err
 	}
 
 	// Add blocks from our store (root block)
 	for k, v := range store.Bag {
-		fmt.Println("Adding block", k)
-		c, err := cid.Parse(k)
-		if err != nil {
-			fmt.Println("Error here:", c, err)
-		}
-
-		c, err = cid.Decode(k)
-		if err != nil {
-			fmt.Println("Error here:", c, err)
-			// Adding block q@T:['-j+>Ow311=%hf좢B'6g
-			// 2023/07/05 10:24:43 invalid cid: selected encoding not supported
-			// return err
-		}
-
+		// cid.Parse and cid.Decode does not work here, using:
 		// https://github.com/ipld/go-ipld-prime/blob/65bfa53512f2328d19273e471ce4fd6d964055a2/storage/bsadapter/bsadapter.go#L87-L89
-		c, err = cidFromBinString(k)
+		c, err := cidFromBinString(k)
 		if err != nil {
-			fmt.Println("Error here:", c, err)
-			// return err
+			return err
 		}
 
 		blk, err := blocks.NewBlockWithCid(v, c)
@@ -177,8 +111,6 @@ func Merge(inputPaths []string, outputPath string) error {
 			return err
 		}
 
-		// that call doesn't work: the cid produced is not the one we get as "root cid"
-		// blk := blocks.NewBlock(v)
 		err = rout.Put(context.Background(), blk)
 		if err != nil {
 			return err
@@ -193,21 +125,17 @@ func Merge(inputPaths []string, outputPath string) error {
 			blockstore.UseWholeCIDs(true),
 		)
 		if err != nil {
-			fmt.Println("Error here:1", err)
 			return err
 		}
 
 		cids, err := robs.AllKeysChan(context.Background())
 		if err != nil {
-			fmt.Println("Error here:2", err)
 			return err
 		}
 
 		for c := range cids {
-			// fmt.Printf("Adding %s\n", c.String())
 			block, err := robs.Get(context.Background(), c)
 			if err != nil {
-				fmt.Println("Error here:3", err)
 				return err
 			}
 

--- a/tooling/car/merge.go
+++ b/tooling/car/merge.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/ipfs/go-cid"
+	carv2 "github.com/ipld/go-car/v2"
 	"github.com/ipld/go-car/v2/blockstore"
 )
 
@@ -31,7 +32,8 @@ func Merge(inputPaths []string, outputPath string) error {
 
 	// Now prepare our new CAR file
 	fmt.Printf("Opening the %s file, with roots: %v\n", outputPath, roots)
-	rout, err := blockstore.OpenReadWrite(outputPath, roots)
+	options := []carv2.Option{blockstore.WriteAsCarV1(true)}
+	rout, err := blockstore.OpenReadWrite(outputPath, roots[0:1], options...)
 	if err != nil {
 		return err
 	}

--- a/tooling/car/merge.go
+++ b/tooling/car/merge.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	blocks "github.com/ipfs/go-block-format"
 	"github.com/ipfs/go-cid"
 	carv2 "github.com/ipld/go-car/v2"
 	"github.com/ipld/go-car/v2/blockstore"
@@ -47,23 +48,52 @@ func Merge(inputPaths []string, outputPath string) error {
 		}
 	})
 
+	// NOTE: by default we generate super large CIDs (from the doc)
+	// which are not compatible with dns.
+	// lp := cidlink.LinkPrototype{Prefix: cid.Prefix{
+	// 	Version:  1,    // Usually '1'.
+	// 	Codec:    0x71, // 0x71 means "dag-cbor" -- See the multicodecs table: https://github.com/multiformats/multicodec/
+	// 	MhType:   0x13, // 0x20 means "sha2-512" -- See the multicodecs table: https://github.com/multiformats/multicodec/
+	// 	MhLength: 64,   // sha2-512 hash has a 64-byte sum.
+	// }}
+	// cid: bafyrgqhpkthtuhnrvrnzobebylknmj4ayxac2f3kfm7pxm5ywmhu65ztzuyz4mmrhwf4sjliwntozivctgwk6qxiquospjybg37o4aiyvzt64
+	// So I switch to sah2-256:
+
+	// lp := cidlink.LinkPrototype{Prefix: cid.Prefix{
+	// 	Version:  1,
+	// 	Codec:    0x71,
+	// 	MhType:   0x12,  // sha2-256
+	// 	MhLength: 32,
+	// }}
+	// Trying to publish that configuratino:
+	/*
+		curl --oauth2-bearer "$W3STORAGE_TOKEN" --data-binary @fixtures.car "https://api.web3.storage/car"
+		{"code":"HTTP_ERROR","message":"protobuf: (PBNode) invalid wireType, expected 2, got 0"}%
+
+		What is that wireType? Maybe we can only publish dag-pb, so let's try.
+	*/
+
 	lp := cidlink.LinkPrototype{Prefix: cid.Prefix{
-		Version:  1,    // Usually '1'.
-		Codec:    0x71, // 0x71 means "dag-cbor" -- See the multicodecs table: https://github.com/multiformats/multicodec/
-		MhType:   0x13, // 0x20 means "sha2-512" -- See the multicodecs table: https://github.com/multiformats/multicodec/
-		MhLength: 64,   // sha2-512 hash has a 64-byte sum.
+		Version:  1,
+		Codec:    0x70, // dag-pb
+		MhType:   0x12,
+		MhLength: 32, // sha2-256
 	}}
+	/**
+	Trying to run with that code, no the code doesn't complete:
+	2023/07/05 10:57:36 func called on wrong kind: "AssignNode" called on a dagpb.PBNode node (kind: list), but only makes sense on map
+	*/
 
 	lnk, err := lsys.Store(
 		linking.LinkContext{},
 		lp,
 		node)
+
 	if err != nil {
 		return err
 	}
 
 	rootCid := lnk.(cidlink.Link).Cid
-
 	fmt.Printf("Root CID: %s\n", rootCid.String())
 
 	// Now prepare our new CAR file
@@ -71,13 +101,34 @@ func Merge(inputPaths []string, outputPath string) error {
 	options := []carv2.Option{blockstore.WriteAsCarV1(true)}
 	rout, err := blockstore.OpenReadWrite(outputPath, []cid.Cid{rootCid}, options...)
 	if err != nil {
+		fmt.Println("Error here0:", err)
 		return err
 	}
 
 	// Add blocks from our store (root block)
-	// TODO: how to?
-	// for every block in our store, add it to `rout`
-	// for ever k, v in store.Bag ????
+	for k, v := range store.Bag {
+		fmt.Println("Adding block", k)
+		c, err := cid.Parse(k)
+		if err != nil {
+			fmt.Println("Error here:", c, err)
+		}
+
+		c, err = cid.Decode(k)
+		if err != nil {
+			fmt.Println("Error here:", c, err)
+			// Adding block q@T:['-j+>Ow311=%hf좢B'6g
+			// 2023/07/05 10:24:43 invalid cid: selected encoding not supported
+			// return err
+		}
+
+		// blk, err := blocks.NewBlockWithCid(v, c)
+		// if err != nil {
+		// 	return err
+		// }
+
+		blk := blocks.NewBlock(v)
+		rout.Put(context.Background(), blk)
+	}
 
 	// Then aggregate all our blocks.
 	for _, path := range inputPaths {
@@ -87,11 +138,13 @@ func Merge(inputPaths []string, outputPath string) error {
 			blockstore.UseWholeCIDs(true),
 		)
 		if err != nil {
+			fmt.Println("Error here:1", err)
 			return err
 		}
 
 		cids, err := robs.AllKeysChan(context.Background())
 		if err != nil {
+			fmt.Println("Error here:2", err)
 			return err
 		}
 
@@ -99,6 +152,7 @@ func Merge(inputPaths []string, outputPath string) error {
 			fmt.Printf("Adding %s\n", c.String())
 			block, err := robs.Get(context.Background(), c)
 			if err != nil {
+				fmt.Println("Error here:3", err)
 				return err
 			}
 
@@ -108,5 +162,6 @@ func Merge(inputPaths []string, outputPath string) error {
 
 	fmt.Printf("Finalizing...\n")
 	err = rout.Finalize()
+
 	return err
 }

--- a/tooling/car/merge.go
+++ b/tooling/car/merge.go
@@ -42,9 +42,30 @@ func Merge(inputPaths []string, outputPath string) error {
 	lsys.SetWriteStorage(&store)
 	lsys.SetReadStorage(&store)
 
-	node := fluent.MustBuildList(basicnode.Prototype.List, int64(len(roots)), func(na fluent.ListAssembler) {
+	// THIS was not compatible with dag pb I think,
+	// node := fluent.MustBuildList(basicnode.Prototype.List, int64(len(roots)), func(na fluent.ListAssembler) {
+	// 	for _, root := range roots {
+	// 		na.AssembleValue().AssignLink(cidlink.Link{Cid: root})
+	// 	}
+	// })
+
+	// creating list of uniq roots
+	uniqRoots := make(map[string]cid.Cid)
+	for _, root := range roots {
+		uniqRoots[root.String()] = root
+	}
+	roots = make([]cid.Cid, 0)
+	for _, root := range uniqRoots {
+		roots = append(roots, root)
+	}
+
+	// Adding to a map, they won't accept duplicate, hence the code above
+	node := fluent.MustBuildMap(basicnode.Prototype.Map, int64(len(roots)), func(ma fluent.MapAssembler) {
 		for _, root := range roots {
-			na.AssembleValue().AssignLink(cidlink.Link{Cid: root})
+			fmt.Println("adding root", root)
+			ma.AssembleEntry(root.String()).AssignLink(cidlink.Link{Cid: root})
+			// getting error:
+			// 2023/07/05 11:13:54 invalid key for map dagpb.PBNode: "bafybeicaj7kvxpcv4neaqzwhrqqmdstu4dhrwfpknrgebq6nzcecfucvyu": no such field
 		}
 	})
 

--- a/tooling/car/merge.go
+++ b/tooling/car/merge.go
@@ -93,7 +93,6 @@ func Merge(inputPaths []string, outputPath string) error {
 	options := []carv2.Option{blockstore.WriteAsCarV1(true)}
 	rout, err := blockstore.OpenReadWrite(outputPath, []cid.Cid{rootCid}, options...)
 	if err != nil {
-		fmt.Println("Error here:a", err)
 		return err
 	}
 


### PR DESCRIPTION
Contributes to #104

Add tooling to run tests over multiple gateways & merge the outputs into a single dashboard. This is using a few arbitrary production gateways for now.

- [x] merges fixtures are now a single car v1 with a single root (makes it compatible with web3.storage)
- [x] add test-prod-e2e CI test
    - [x] upload fixtures to web3.storage
    - [x] run gateway conformance test suite on a few (arbitrary) gateways
    - [x] aggregate results & generate dashboard
- [x] generate a badge
- [x] patch add-to-web3 https://github.com/web3-storage/add-to-web3/pull/86

Example of output: https://github.com/singulargarden/gateway-conformance/actions/runs/5680836848
Example of markdown: https://github.com/laurentsenta/gateway-conformance/blob/main/README.md (it links to ipfs/gateway-conformance, hence the gray status for now)

## follow-up

- Implement a similar test for dev gateways (see https://github.com/ipfs/gateway-conformance/issues/104#issuecomment-1621944117)
- tweak the production gateways we want to test and the specs we cover