### PR TITLE
feat: add IPIP and TestGroup Metadatas

### DIFF
--- a/.github/workflows/test-prod-e2e.yml
+++ b/.github/workflows/test-prod-e2e.yml
@@ -39,7 +39,7 @@ jobs:
           path_to_add: 'fixtures.car'
       - name: Wait for pinning
         run: |
-          sleep 180 # 3 minutes
+          sleep 20 # 20 seconds
           # see rational in https://github.com/ipfs/gateway-conformance/pull/108#discussion_r1274628865
   test:
     runs-on: "ubuntu-latest"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - `--version` flag shows the current version
 - Metadata logging used to associate tests with custom data like versions, specs identifiers, etc.
+- Test Group Metadata on Tests
+- IPIP Metadata on Tests and SugarTest
 
 ## [0.3.0] - 2023-07-31
 ### Added

--- a/tests/metadata_test.go
+++ b/tests/metadata_test.go
@@ -9,3 +9,13 @@ import (
 func TestMetadata(t *testing.T) {
 	tooling.LogVersion(t)
 }
+
+const (
+	GroupTrustlessGateway = "Trustless Gateway"
+	GroupPathGateway      = "Path Gateway"
+	GroupSubdomainGateway = "Subdomain Gateway"
+)
+
+const (
+	IPIP402 = "ipip-0402"
+)

--- a/tests/path_gateway_cors_test.go
+++ b/tests/path_gateway_cors_test.go
@@ -3,11 +3,14 @@ package tests
 import (
 	"testing"
 
+	"github.com/ipfs/gateway-conformance/tooling"
 	"github.com/ipfs/gateway-conformance/tooling/specs"
 	. "github.com/ipfs/gateway-conformance/tooling/test"
 )
 
 func TestCors(t *testing.T) {
+	tooling.LogTestGroup(t, GroupPathGateway)
+
 	cidHello := "bafkqabtimvwgy3yk" // hello
 
 	tests := SugarTests{

--- a/tests/path_gateway_dag_test.go
+++ b/tests/path_gateway_dag_test.go
@@ -3,6 +3,7 @@ package tests
 import (
 	"testing"
 
+	"github.com/ipfs/gateway-conformance/tooling"
 	"github.com/ipfs/gateway-conformance/tooling/car"
 	. "github.com/ipfs/gateway-conformance/tooling/check"
 	"github.com/ipfs/gateway-conformance/tooling/ipns"
@@ -12,6 +13,8 @@ import (
 )
 
 func TestGatewayJsonCbor(t *testing.T) {
+	tooling.LogTestGroup(t, GroupPathGateway)
+
 	fixture := car.MustOpenUnixfsCar("path_gateway_dag/gateway-json-cbor.car")
 
 	fileJSON := fixture.MustGetNode("ą", "ę", "t.json")
@@ -66,6 +69,8 @@ func TestGatewayJsonCbor(t *testing.T) {
 // ## Reading UnixFS (data encoded with dag-pb codec) as DAG-CBOR and DAG-JSON
 // ## (returns representation defined in https://ipld.io/specs/codecs/dag-pb/spec/#logical-format)
 func TestDagPbConversion(t *testing.T) {
+	tooling.LogTestGroup(t, GroupPathGateway)
+
 	fixture := car.MustOpenUnixfsCar("path_gateway_dag/gateway-json-cbor.car")
 
 	dir := fixture.MustGetRoot()
@@ -205,6 +210,8 @@ func TestDagPbConversion(t *testing.T) {
 // # Requesting CID with plain json (0x0200) and cbor (0x51) codecs
 // # (note these are not UnixFS, not DAG-* variants, just raw block identified by a CID with a special codec)
 func TestPlainCodec(t *testing.T) {
+	tooling.LogTestGroup(t, GroupPathGateway)
+
 	table := []struct {
 		Name        string
 		Format      string
@@ -308,6 +315,8 @@ func TestPlainCodec(t *testing.T) {
 
 // ## Pathing, traversal over DAG-JSON and DAG-CBOR
 func TestPathing(t *testing.T) {
+	tooling.LogTestGroup(t, GroupPathGateway)
+
 	dagJSONTraversal := car.MustOpenUnixfsCar("path_gateway_dag/dag-json-traversal.car").MustGetRoot()
 	dagCBORTraversal := car.MustOpenUnixfsCar("path_gateway_dag/dag-cbor-traversal.car").MustGetRoot()
 
@@ -381,6 +390,8 @@ func TestPathing(t *testing.T) {
 // ## NATIVE TESTS for DAG-JSON (0x0129) and DAG-CBOR (0x71):
 // ## DAG- regression tests for core behaviors when native DAG-(CBOR|JSON) is requested
 func TestNativeDag(t *testing.T) {
+	tooling.LogTestGroup(t, GroupPathGateway)
+
 	missingCID := car.RandomCID()
 
 	table := []struct {
@@ -570,6 +581,8 @@ func TestNativeDag(t *testing.T) {
 }
 
 func TestGatewayJSONCborAndIPNS(t *testing.T) {
+	tooling.LogTestGroup(t, GroupPathGateway)
+
 	ipnsIdDagJSON := "k51qzi5uqu5dhjghbwdvbo6mi40htrq6e2z4pwgp15pgv3ho1azvidttzh8yy2"
 	ipnsIdDagCBOR := "k51qzi5uqu5dghjous0agrwavl8vzl64xckoqzwqeqwudfr74kfd11zcyk3b7l"
 

--- a/tests/path_gateway_ipns_test.go
+++ b/tests/path_gateway_ipns_test.go
@@ -3,11 +3,14 @@ package tests
 import (
 	"testing"
 
+	"github.com/ipfs/gateway-conformance/tooling"
 	"github.com/ipfs/gateway-conformance/tooling/specs"
 	. "github.com/ipfs/gateway-conformance/tooling/test"
 )
 
 func TestRedirectCanonicalIPNS(t *testing.T) {
+	tooling.LogTestGroup(t, GroupPathGateway)
+
 	tests := SugarTests{
 		{
 			Name: "GET for /ipns/{b58-multihash-of-ed25519-key} redirects to /ipns/{cidv1-libp2p-key-base36}",

--- a/tests/path_gateway_raw_test.go
+++ b/tests/path_gateway_raw_test.go
@@ -5,12 +5,15 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/ipfs/gateway-conformance/tooling"
 	"github.com/ipfs/gateway-conformance/tooling/car"
 	"github.com/ipfs/gateway-conformance/tooling/specs"
 	. "github.com/ipfs/gateway-conformance/tooling/test"
 )
 
 func TestGatewayBlock(t *testing.T) {
+	tooling.LogTestGroup(t, GroupPathGateway)
+
 	fixture := car.MustOpenUnixfsCar("gateway-raw-block.car")
 
 	tests := SugarTests{

--- a/tests/path_gateway_tar_test.go
+++ b/tests/path_gateway_tar_test.go
@@ -3,6 +3,7 @@ package tests
 import (
 	"testing"
 
+	"github.com/ipfs/gateway-conformance/tooling"
 	"github.com/ipfs/gateway-conformance/tooling/car"
 	. "github.com/ipfs/gateway-conformance/tooling/check"
 	"github.com/ipfs/gateway-conformance/tooling/specs"
@@ -11,6 +12,8 @@ import (
 )
 
 func TestTar(t *testing.T) {
+	tooling.LogTestGroup(t, GroupPathGateway)
+
 	fixtureOutside := car.MustOpenUnixfsCar("path_gateway_tar/outside-root.car")
 	fixtureInside := car.MustOpenUnixfsCar("path_gateway_tar/inside-root.car")
 

--- a/tests/path_gateway_unixfs_test.go
+++ b/tests/path_gateway_unixfs_test.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/ipfs/gateway-conformance/tooling"
 	"github.com/ipfs/gateway-conformance/tooling/car"
 	. "github.com/ipfs/gateway-conformance/tooling/check"
 	"github.com/ipfs/gateway-conformance/tooling/ipns"
@@ -13,6 +14,8 @@ import (
 )
 
 func TestUnixFSDirectoryListing(t *testing.T) {
+	tooling.LogTestGroup(t, GroupPathGateway)
+
 	fixture := car.MustOpenUnixfsCar("dir_listing/fixtures.car")
 	root := fixture.MustGetNode()
 	file := fixture.MustGetNode("ą", "ę", "file-źł.txt")
@@ -76,6 +79,8 @@ func TestUnixFSDirectoryListing(t *testing.T) {
 }
 
 func TestGatewayCache(t *testing.T) {
+	tooling.LogTestGroup(t, GroupPathGateway)
+
 	fixture := car.MustOpenUnixfsCar("gateway-cache/fixtures.car")
 
 	tests := SugarTests{
@@ -308,6 +313,8 @@ func TestGatewayCache(t *testing.T) {
 }
 
 func TestGatewayCacheWithIPNS(t *testing.T) {
+	tooling.LogTestGroup(t, GroupPathGateway)
+
 	fixture := car.MustOpenUnixfsCar("gateway-cache/fixtures.car")
 	ipns := ipns.MustOpenIPNSRecordWithKey("gateway-cache/k51qzi5uqu5dlxdsdu5fpuu7h69wu4ohp32iwm9pdt9nq3y5rpn3ln9j12zfhe.ipns-record")
 	ipnsKey := ipns.Key()
@@ -404,6 +411,8 @@ func TestGatewayCacheWithIPNS(t *testing.T) {
 }
 
 func TestGatewaySymlink(t *testing.T) {
+	tooling.LogTestGroup(t, GroupPathGateway)
+
 	fixture := car.MustOpenUnixfsCar("path_gateway_unixfs/symlink.car")
 	rootDirCID := fixture.MustGetCid()
 
@@ -443,6 +452,8 @@ func TestGatewaySymlink(t *testing.T) {
 }
 
 func TestGatewayUnixFSFileRanges(t *testing.T) {
+	tooling.LogTestGroup(t, GroupPathGateway)
+
 	// Multi-range requests MUST conform to the HTTP semantics. The server does not
 	// need to be able to support returning multiple ranges. However, it must respond
 	// correctly.

--- a/tests/subdomain_gateway_ipfs_test.go
+++ b/tests/subdomain_gateway_ipfs_test.go
@@ -4,6 +4,7 @@ import (
 	"net/url"
 	"testing"
 
+	"github.com/ipfs/gateway-conformance/tooling"
 	"github.com/ipfs/gateway-conformance/tooling/car"
 	. "github.com/ipfs/gateway-conformance/tooling/check"
 	"github.com/ipfs/gateway-conformance/tooling/helpers"
@@ -12,6 +13,8 @@ import (
 )
 
 func TestUnixFSDirectoryListingOnSubdomainGateway(t *testing.T) {
+	tooling.LogTestGroup(t, GroupSubdomainGateway)
+
 	fixture := car.MustOpenUnixfsCar("dir_listing/fixtures.car")
 	root := fixture.MustGetNode()
 	file := fixture.MustGetNode("ą", "ę", "file-źł.txt")
@@ -105,6 +108,8 @@ func TestUnixFSDirectoryListingOnSubdomainGateway(t *testing.T) {
 }
 
 func TestGatewaySubdomains(t *testing.T) {
+	tooling.LogTestGroup(t, GroupSubdomainGateway)
+
 	fixture := car.MustOpenUnixfsCar("subdomain_gateway/fixtures.car")
 
 	CIDVal := string(fixture.MustGetRawData("hello-CIDv1")) // hello

--- a/tests/subdomain_gateway_ipns_test.go
+++ b/tests/subdomain_gateway_ipns_test.go
@@ -4,6 +4,7 @@ import (
 	"net/url"
 	"testing"
 
+	"github.com/ipfs/gateway-conformance/tooling"
 	"github.com/ipfs/gateway-conformance/tooling/car"
 	"github.com/ipfs/gateway-conformance/tooling/dnslink"
 	"github.com/ipfs/gateway-conformance/tooling/helpers"
@@ -15,6 +16,8 @@ import (
 )
 
 func TestGatewaySubdomainAndIPNS(t *testing.T) {
+	tooling.LogTestGroup(t, GroupSubdomainGateway)
+
 	tests := SugarTests{}
 
 	rsaFixture := ipns.MustOpenIPNSRecordWithKey("subdomain_gateway/QmVujd5Vb7moysJj8itnGufN7MEtPRCNHkKpNuA4onsRa3.ipns-record")
@@ -159,6 +162,8 @@ func TestGatewaySubdomainAndIPNS(t *testing.T) {
 }
 
 func TestSubdomainGatewayDNSLinkInlining(t *testing.T) {
+	tooling.LogTestGroup(t, GroupSubdomainGateway)
+
 	tests := SugarTests{}
 
 	// We're going to run the same test against multiple gateways (localhost, and a subdomain gateway)

--- a/tests/trustless_gateway_car_test.go
+++ b/tests/trustless_gateway_car_test.go
@@ -3,6 +3,7 @@ package tests
 import (
 	"testing"
 
+	"github.com/ipfs/gateway-conformance/tooling"
 	"github.com/ipfs/gateway-conformance/tooling/car"
 	. "github.com/ipfs/gateway-conformance/tooling/check"
 	"github.com/ipfs/gateway-conformance/tooling/helpers"
@@ -11,6 +12,8 @@ import (
 )
 
 func TestTrustlessCarPathing(t *testing.T) {
+	tooling.LogTestGroup(t, GroupTrustlessGateway)
+
 	subdirTwoSingleBlockFilesFixture := car.MustOpenUnixfsCar("trustless_gateway_car/subdir-with-two-single-block-files.car")
 	singleLayerHamtMultiBlockFilesFixture := car.MustOpenUnixfsCar("trustless_gateway_car/single-layer-hamt-with-multi-block-files.car")
 	dirWithDagCborWithLinksFixture := car.MustOpenUnixfsCar("trustless_gateway_car/dir-with-dag-cbor-with-links.car")
@@ -39,6 +42,7 @@ func TestTrustlessCarPathing(t *testing.T) {
 						Exactly().
 						InThatOrder(),
 				),
+			IPIP: IPIP402,
 		},
 		{
 			Name: "GET default CAR response of UnixFS file on a path with HAMT-sharded directory",
@@ -94,6 +98,8 @@ func TestTrustlessCarPathing(t *testing.T) {
 }
 
 func TestTrustlessCarDagScopeBlock(t *testing.T) {
+	tooling.LogTestGroup(t, GroupTrustlessGateway)
+
 	subdirTwoSingleBlockFilesFixture := car.MustOpenUnixfsCar("trustless_gateway_car/subdir-with-two-single-block-files.car")
 	singleLayerHamtMultiBlockFilesFixture := car.MustOpenUnixfsCar("trustless_gateway_car/single-layer-hamt-with-multi-block-files.car")
 
@@ -177,6 +183,8 @@ func TestTrustlessCarDagScopeBlock(t *testing.T) {
 }
 
 func TestTrustlessCarDagScopeEntity(t *testing.T) {
+	tooling.LogTestGroup(t, GroupTrustlessGateway)
+
 	subdirTwoSingleBlockFilesFixture := car.MustOpenUnixfsCar("trustless_gateway_car/subdir-with-two-single-block-files.car")
 	singleLayerHamtMultiBlockFilesFixture := car.MustOpenUnixfsCar("trustless_gateway_car/single-layer-hamt-with-multi-block-files.car")
 	subdirWithMixedBlockFiles := car.MustOpenUnixfsCar("trustless_gateway_car/subdir-with-mixed-block-files.car")
@@ -311,6 +319,8 @@ func TestTrustlessCarDagScopeEntity(t *testing.T) {
 }
 
 func TestTrustlessCarDagScopeAll(t *testing.T) {
+	tooling.LogTestGroup(t, GroupTrustlessGateway)
+
 	subdirWithMixedBlockFiles := car.MustOpenUnixfsCar("trustless_gateway_car/subdir-with-mixed-block-files.car")
 
 	tests := SugarTests{
@@ -374,6 +384,9 @@ func TestTrustlessCarDagScopeAll(t *testing.T) {
 }
 
 func TestTrustlessCarEntityBytes(t *testing.T) {
+	tooling.LogTestGroup(t, GroupTrustlessGateway)
+	tooling.LogIPIP(t, IPIP402, "4.2.2")
+
 	singleLayerHamtMultiBlockFilesFixture := car.MustOpenUnixfsCar("trustless_gateway_car/single-layer-hamt-with-multi-block-files.car")
 	subdirWithMixedBlockFiles := car.MustOpenUnixfsCar("trustless_gateway_car/subdir-with-mixed-block-files.car")
 	missingBlockFixture := car.MustOpenUnixfsCar("trustless_gateway_car/file-3k-and-3-blocks-missing-block.car")
@@ -634,6 +647,8 @@ func TestTrustlessCarEntityBytes(t *testing.T) {
 }
 
 func TestTrustlessCarOrderAndDuplicates(t *testing.T) {
+	tooling.LogTestGroup(t, GroupTrustlessGateway)
+
 	dirWithDuplicateFiles := car.MustOpenUnixfsCar("trustless_gateway_car/dir-with-duplicate-files.car")
 	// This array is defined at the SPEC level and should not depend on library behavior
 	// See the recipe for `dir-with-duplicate-files.car`

--- a/tests/trustless_gateway_ipns_test.go
+++ b/tests/trustless_gateway_ipns_test.go
@@ -3,6 +3,7 @@ package tests
 import (
 	"testing"
 
+	"github.com/ipfs/gateway-conformance/tooling"
 	"github.com/ipfs/gateway-conformance/tooling/car"
 	. "github.com/ipfs/gateway-conformance/tooling/ipns"
 	"github.com/ipfs/gateway-conformance/tooling/specs"
@@ -10,6 +11,8 @@ import (
 )
 
 func TestGatewayIPNSRecord(t *testing.T) {
+	tooling.LogTestGroup(t, GroupTrustlessGateway)
+
 	fixture := car.MustOpenUnixfsCar("ipns_records/fixtures.car")
 	file := fixture.MustGetRoot()
 	fileCID := file.Cid()

--- a/tests/trustless_gateway_raw_test.go
+++ b/tests/trustless_gateway_raw_test.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/ipfs/gateway-conformance/tooling"
 	"github.com/ipfs/gateway-conformance/tooling/car"
 	. "github.com/ipfs/gateway-conformance/tooling/check"
 	"github.com/ipfs/gateway-conformance/tooling/specs"
@@ -12,6 +13,8 @@ import (
 )
 
 func TestTrustlessRaw(t *testing.T) {
+	tooling.LogTestGroup(t, GroupTrustlessGateway)
+
 	fixture := car.MustOpenUnixfsCar("gateway-raw-block.car")
 
 	tests := SugarTests{
@@ -128,6 +131,8 @@ func TestTrustlessRaw(t *testing.T) {
 }
 
 func TestTrustlessRawRanges(t *testing.T) {
+	tooling.LogTestGroup(t, GroupTrustlessGateway)
+
 	// Multi-range requests MUST conform to the HTTP semantics. The server does not
 	// need to be able to support returning multiple ranges. However, it must respond
 	// correctly.

--- a/tooling/metadata.go
+++ b/tooling/metadata.go
@@ -16,6 +16,28 @@ func LogMetadata(t *testing.T, value interface{}) {
 	t.Logf("--- META: %s", string(jsonValue))
 }
 
+func LogTestGroup(t *testing.T, name string) {
+	t.Helper()
+
+	LogMetadata(t, struct {
+		Group string `json:"group"`
+	}{
+		Group: name,
+	})
+}
+
+func LogIPIP(t *testing.T, ipip string, sections ...string) {
+	t.Helper()
+
+	LogMetadata(t, struct {
+		IPIP     string   `json:"ipip"`
+		Sections []string `json:"sections,omitempty"`
+	}{
+		IPIP:     ipip,
+		Sections: sections,
+	})
+}
+
 func LogVersion(t *testing.T) {
 	LogMetadata(t, struct {
 		Version string `json:"version"`

--- a/tooling/metadata.go
+++ b/tooling/metadata.go
@@ -6,6 +6,8 @@ import (
 )
 
 func LogMetadata(t *testing.T, value interface{}) {
+	t.Helper()
+
 	jsonValue, err := json.Marshal(value)
 	if err != nil {
 		t.Errorf("Failed to encode value: %v", err)

--- a/tooling/test/test.go
+++ b/tooling/test/test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/ipfs/gateway-conformance/tooling"
 	"github.com/ipfs/gateway-conformance/tooling/specs"
 )
 
@@ -16,6 +17,7 @@ type SugarTest struct {
 	Requests  []RequestBuilder
 	Response  ExpectBuilder
 	Responses ExpectsBuilder
+	IPIP      string
 }
 
 type SugarTests []SugarTest
@@ -51,6 +53,10 @@ func run(t *testing.T, tests SugarTests) {
 
 		if len(test.Requests) > 0 {
 			t.Run(test.Name, func(t *testing.T) {
+				if test.IPIP != "" {
+					tooling.LogIPIP(t, test.IPIP)
+				}
+
 				responses := make([]*http.Response, 0, len(test.Requests))
 
 				for _, req := range test.Requests {
@@ -63,6 +69,10 @@ func run(t *testing.T, tests SugarTests) {
 			})
 		} else {
 			t.Run(test.Name, func(t *testing.T) {
+				if test.IPIP != "" {
+					tooling.LogIPIP(t, test.IPIP)
+				}
+
 				_, res, localReport := runRequest(timeout, t, test, test.Request)
 				validateResponse(t, test.Response, res, localReport)
 			})


### PR DESCRIPTION
Contributes to https://github.com/ipfs/gateway-conformance/issues/123
Related comment: https://github.com/ipfs/gateway-conformance/pull/116/files#r1277390949

To implement Dashboards, we introduce:

- The ability to define "human readable"  test groups in code, which do not depend on the test structure, these could be used to generate user-friendly tables like the one in [public-gateway-checker](https://ipfs-public-gateway-checker.on.fleek.co/).
- The ability to associate IPIPs reference with a test case and also link to subsections.

**Example Output: https://github.com/ipfs/gateway-conformance/actions/runs/5880695313/attempts/1#summary-15947714091**
Note how the tests are grouped, and how `TrustlessCarEntityBytes` links to the corresponding ipip

## Todos

- [x] Introduce the metadata APIs required
- [x] Draft a dashboard output that relies on these new specs
- [x] Implement a generator that outputs the groups, versions, and IPIPs

## Follow-ups

- [ ] demonstrate a more scalable generator that relies on turning outputs "queriable" data
- [ ] demonstrate a reverse-index that goes from an IPIP and list all the tests (when linked from the specs)
- [ ] When the need arise, we can add IPIP markers to a check (like a single header or payload test)