### PR TITLE
feat: 404 test for trustless gateway CARs

### DIFF
--- a/tests/trustless_gateway_car_test.go
+++ b/tests/trustless_gateway_car_test.go
@@ -88,6 +88,30 @@ func TestTrustlessCarPathing(t *testing.T) {
 						InThatOrder(),
 				),
 		},
+		{
+			Name: "GET default CAR response for non-existing file",
+			Hint: `
+				CAR stream of a non-existing path must return 200 OK and all the blocks necessary
+				to traverse the path up to and including the parent of the first non-existing
+				segment of the path, in order to allow the client to verify that the request
+				path does not exist.
+			`,
+			Request: Request().
+				Path("/ipfs/{{cid}}/subdir/i-do-not-exist", subdirTwoSingleBlockFilesFixture.MustGetCidWithCodec(0x70)).
+				Query("format", "car"),
+			Response: Expect().
+				Status(200).
+				Body(
+					IsCar().
+						IgnoreRoots().
+						HasBlocks(
+							subdirTwoSingleBlockFilesFixture.MustGetCid(),
+							subdirTwoSingleBlockFilesFixture.MustGetCid("subdir"),
+						).
+						Exactly().
+						InThatOrder(),
+				),
+		},
 	}
 
 	RunWithSpecs(t, helpers.StandardCARTestTransforms(t, tests), specs.TrustlessGatewayCAR)


### PR DESCRIPTION
Closes #126.

- Adds test for non-existing paths as defined in #126.
- This test will fail against both Kubo master and Kubo latest until https://github.com/ipfs/kubo/pull/10024 is merged.