### PR TITLE
feat: test 404 on UnixFS and DAG-JSON/CBOR paths

### DIFF
--- a/tests/path_gateway_dag_test.go
+++ b/tests/path_gateway_dag_test.go
@@ -11,8 +11,6 @@ import (
 	. "github.com/ipfs/gateway-conformance/tooling/tmpl"
 )
 
-// TODO(laurent): this was t0123_gateway_json_cbor_test
-
 func TestGatewayJsonCbor(t *testing.T) {
 	fixture := car.MustOpenUnixfsCar("path_gateway_dag/gateway-json-cbor.car")
 
@@ -67,7 +65,7 @@ func TestGatewayJsonCbor(t *testing.T) {
 
 // ## Reading UnixFS (data encoded with dag-pb codec) as DAG-CBOR and DAG-JSON
 // ## (returns representation defined in https://ipld.io/specs/codecs/dag-pb/spec/#logical-format)
-func TestDAgPbConversion(t *testing.T) {
+func TestDagPbConversion(t *testing.T) {
 	fixture := car.MustOpenUnixfsCar("path_gateway_dag/gateway-json-cbor.car")
 
 	dir := fixture.MustGetRoot()
@@ -340,6 +338,13 @@ func TestPathing(t *testing.T) {
 				),
 		},
 		{
+			Name: "GET DAG-JSON returns 404 on non-existing link",
+			Request: Request().
+				Path("/ipfs/{{cid}}/foo/i-do-not-exist", dagJSONTraversalCID),
+			Response: Expect().
+				Status(404),
+		},
+		{
 			Name: "GET DAG-CBOR traversal returns 501 if there is path remainder",
 			Request: Request().
 				Path("/ipfs/{{cid}}/foo", dagCBORTraversalCID).
@@ -360,6 +365,13 @@ func TestPathing(t *testing.T) {
 					// 		 but we might prefer matching abstract values, something like "IsJSONEqual(someFixture.formatedAsJSON))"
 					IsJSONEqual([]byte(`{"hello": "this is not a link"}`)),
 				),
+		},
+		{
+			Name: "GET DAG-CBOR returns 404 on non-existing link",
+			Request: Request().
+				Path("/ipfs/{{cid}}/foo/i-do-not-exist", dagCBORTraversalCID),
+			Response: Expect().
+				Status(404),
 		},
 	}
 

--- a/tests/path_gateway_unixfs_test.go
+++ b/tests/path_gateway_unixfs_test.go
@@ -63,6 +63,13 @@ func TestUnixFSDirectoryListing(t *testing.T) {
 						Contains(`<a class="ipfs-hash" translate="no" href="/ipfs/{{cid}}?filename=file-%25C5%25BA%25C5%2582.txt">`, file.Cid())),
 				),
 		},
+		{
+			Name: "GET for /ipfs/cid/file UnixFS file that does not exist returns 404",
+			Request: Request().
+				Path("/ipfs/{{cid}}/i-do-not-exist", root.Cid()),
+			Response: Expect().
+				Status(404),
+		},
 	}
 
 	RunWithSpecs(t, tests, specs.PathGatewayUnixFS)

--- a/tests/subdomain_gateway_ipfs_test.go
+++ b/tests/subdomain_gateway_ipfs_test.go
@@ -11,8 +11,6 @@ import (
 	. "github.com/ipfs/gateway-conformance/tooling/test"
 )
 
-// TODO(laurent): this was in t0115_gateway_dir_listing_test.go
-
 func TestUnixFSDirectoryListingOnSubdomainGateway(t *testing.T) {
 	fixture := car.MustOpenUnixfsCar("dir_listing/fixtures.car")
 	root := fixture.MustGetNode()


### PR DESCRIPTION
Closes #127. Adds some 404 tests as per the issue.