### PR TITLE
fix: refs in extract fixtures and test

### DIFF
--- a/.github/actions/extract-fixtures/action.yml
+++ b/.github/actions/extract-fixtures/action.yml
@@ -22,6 +22,6 @@ runs:
         MERGED: ${{ inputs.merged }}
       with:
         repository: ${{ steps.github.outputs.action_repository }}
-        ref: ${{ steps.github.outputs.action_ref }}
+        ref: ${{ steps.github.outputs.action_sha || steps.github.outputs.action_ref }}
         dockerfile: Dockerfile
         args: extract-fixtures --directory="$OUTPUT" --merged="$MERGED"

--- a/.github/actions/test/action.yml
+++ b/.github/actions/test/action.yml
@@ -42,7 +42,7 @@ runs:
         SPECS: ${{ inputs.specs }}
       with:
         repository: ${{ steps.github.outputs.action_repository }}
-        ref: ${{ steps.github.outputs.action_ref }}
+        ref: ${{ steps.github.outputs.action_sha || steps.github.outputs.action_ref }}
         dockerfile: Dockerfile
         opts: --network=host
         args: test --url="$URL" --json="$JSON" --specs="$SPECS" --subdomain-url="$SUBDOMAIN" -- ${{ inputs.args }}


### PR DESCRIPTION
This is needed because of the upstream fixes we applied to GitHub action in docker container action. Action ref output now holds ref instead of a sha like before.