### PR TITLE
ci: remove obsolete protocol/cache-go-action

### DIFF
--- a/.github/workflows/test-kubo-e2e.yml
+++ b/.github/workflows/test-kubo-e2e.yml
@@ -3,7 +3,7 @@ name: Test Kubo (e2e)
 on:
   workflow_dispatch:
   push:
-    branches: 
+    branches:
       - main
   pull_request:
 
@@ -19,7 +19,7 @@ jobs:
         shell: bash
     steps:
       - name: Setup Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v4
         with:
           go-version: 1.20.4
       - uses: actions/checkout@v3
@@ -29,7 +29,6 @@ jobs:
         uses: ./gateway-conformance/.github/actions/extract-fixtures
         with:
           output: fixtures
-      - uses: protocol/cache-go-action@v1
       - run: go install github.com/ipfs/kubo/cmd/ipfs@${{ matrix.target }}
         shell: bash
         env:


### PR DESCRIPTION
setup-go@v4 comes with Go modules caching enabled by default.