### PR TITLE
feat: add user-oriented taxonomy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Metadata logging used to associate tests with custom data like versions, specs identifiers, etc.
 - Output Github's workflow URL with metadata. [PR](https://github.com/ipfs/gateway-conformance/pull/145)
 - Basic Dashboard Output with content generation. [PR](https://github.com/ipfs/gateway-conformance/pull/152)
+- Test Group Metadata on Tests. [PR](https://github.com/ipfs/gateway-conformance/pull/156)
 
 ## [0.3.0] - 2023-07-31
 ### Added

--- a/tests/dnslink_gateway_test.go
+++ b/tests/dnslink_gateway_test.go
@@ -4,6 +4,7 @@ import (
 	"net/url"
 	"testing"
 
+	"github.com/ipfs/gateway-conformance/tooling"
 	"github.com/ipfs/gateway-conformance/tooling/car"
 	. "github.com/ipfs/gateway-conformance/tooling/check"
 	"github.com/ipfs/gateway-conformance/tooling/dnslink"
@@ -14,6 +15,8 @@ import (
 )
 
 func TestDNSLinkGatewayUnixFSDirectoryListing(t *testing.T) {
+	tooling.LogTestGroup(t, GroupDNSLink)
+
 	fixture := car.MustOpenUnixfsCar("dir_listing/fixtures.car")
 	file := fixture.MustGetNode("ą", "ę", "file-źł.txt")
 

--- a/tests/metadata_test.go
+++ b/tests/metadata_test.go
@@ -13,9 +13,12 @@ func TestMetadata(t *testing.T) {
 }
 
 const (
-	GroupTrustlessGateway = "Trustless Gateway"
-	GroupPathGateway      = "Path Gateway"
-	GroupSubdomainGateway = "Subdomain Gateway"
-	GroupCORS             = "CORS"
-	GroupIPNS             = "IPNS"
+	GroupSubdomains = "Subdomains"
+	GroupCORS       = "CORS"
+	GroupIPNS       = "IPNS"
+	GroupDNSLink    = "DNSLink"
+	GroupJSONCbor   = "JSON-CBOR"
+	GroupBlockCar   = "Block-CAR"
+	GroupTar        = "Tar"
+	GroupUnixFS     = "UnixFS"
 )

--- a/tests/metadata_test.go
+++ b/tests/metadata_test.go
@@ -11,3 +11,11 @@ func TestMetadata(t *testing.T) {
 	tooling.LogJobURL(t)
 	tooling.LogGatewayURL(t)
 }
+
+const (
+	GroupTrustlessGateway = "Trustless Gateway"
+	GroupPathGateway      = "Path Gateway"
+	GroupSubdomainGateway = "Subdomain Gateway"
+	GroupCORS             = "CORS"
+	GroupIPNS             = "IPNS"
+)

--- a/tests/path_gateway_cors_test.go
+++ b/tests/path_gateway_cors_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestCors(t *testing.T) {
-	tooling.LogTestGroup(t, GroupPathGateway)
+	tooling.LogTestGroup(t, GroupCORS)
 
 	cidHello := "bafkqabtimvwgy3yk" // hello
 

--- a/tests/path_gateway_cors_test.go
+++ b/tests/path_gateway_cors_test.go
@@ -3,11 +3,14 @@ package tests
 import (
 	"testing"
 
+	"github.com/ipfs/gateway-conformance/tooling"
 	"github.com/ipfs/gateway-conformance/tooling/specs"
 	. "github.com/ipfs/gateway-conformance/tooling/test"
 )
 
 func TestCors(t *testing.T) {
+	tooling.LogTestGroup(t, GroupPathGateway)
+
 	cidHello := "bafkqabtimvwgy3yk" // hello
 
 	tests := SugarTests{

--- a/tests/path_gateway_dag_test.go
+++ b/tests/path_gateway_dag_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestGatewayJsonCbor(t *testing.T) {
-	tooling.LogTestGroup(t, GroupPathGateway)
+	tooling.LogTestGroup(t, GroupJSONCbor)
 
 	fixture := car.MustOpenUnixfsCar("path_gateway_dag/gateway-json-cbor.car")
 
@@ -69,7 +69,7 @@ func TestGatewayJsonCbor(t *testing.T) {
 // ## Reading UnixFS (data encoded with dag-pb codec) as DAG-CBOR and DAG-JSON
 // ## (returns representation defined in https://ipld.io/specs/codecs/dag-pb/spec/#logical-format)
 func TestDagPbConversion(t *testing.T) {
-	tooling.LogTestGroup(t, GroupPathGateway)
+	tooling.LogTestGroup(t, GroupJSONCbor)
 
 	fixture := car.MustOpenUnixfsCar("path_gateway_dag/gateway-json-cbor.car")
 
@@ -210,7 +210,7 @@ func TestDagPbConversion(t *testing.T) {
 // # Requesting CID with plain json (0x0200) and cbor (0x51) codecs
 // # (note these are not UnixFS, not DAG-* variants, just raw block identified by a CID with a special codec)
 func TestPlainCodec(t *testing.T) {
-	tooling.LogTestGroup(t, GroupPathGateway)
+	tooling.LogTestGroup(t, GroupJSONCbor)
 
 	table := []struct {
 		Name        string
@@ -315,7 +315,7 @@ func TestPlainCodec(t *testing.T) {
 
 // ## Pathing, traversal over DAG-JSON and DAG-CBOR
 func TestPathing(t *testing.T) {
-	tooling.LogTestGroup(t, GroupPathGateway)
+	tooling.LogTestGroup(t, GroupJSONCbor)
 
 	dagJSONTraversal := car.MustOpenUnixfsCar("path_gateway_dag/dag-json-traversal.car").MustGetRoot()
 	dagCBORTraversal := car.MustOpenUnixfsCar("path_gateway_dag/dag-cbor-traversal.car").MustGetRoot()
@@ -390,7 +390,7 @@ func TestPathing(t *testing.T) {
 // ## NATIVE TESTS for DAG-JSON (0x0129) and DAG-CBOR (0x71):
 // ## DAG- regression tests for core behaviors when native DAG-(CBOR|JSON) is requested
 func TestNativeDag(t *testing.T) {
-	tooling.LogTestGroup(t, GroupPathGateway)
+	tooling.LogTestGroup(t, GroupJSONCbor)
 
 	missingCID := car.RandomCID()
 
@@ -581,7 +581,7 @@ func TestNativeDag(t *testing.T) {
 }
 
 func TestGatewayJSONCborAndIPNS(t *testing.T) {
-	tooling.LogTestGroup(t, GroupPathGateway)
+	tooling.LogTestGroup(t, GroupIPNS)
 
 	ipnsIdDagJSON := "k51qzi5uqu5dhjghbwdvbo6mi40htrq6e2z4pwgp15pgv3ho1azvidttzh8yy2"
 	ipnsIdDagCBOR := "k51qzi5uqu5dghjous0agrwavl8vzl64xckoqzwqeqwudfr74kfd11zcyk3b7l"

--- a/tests/path_gateway_dag_test.go
+++ b/tests/path_gateway_dag_test.go
@@ -3,6 +3,7 @@ package tests
 import (
 	"testing"
 
+	"github.com/ipfs/gateway-conformance/tooling"
 	"github.com/ipfs/gateway-conformance/tooling/car"
 	. "github.com/ipfs/gateway-conformance/tooling/check"
 	"github.com/ipfs/gateway-conformance/tooling/ipns"
@@ -12,6 +13,8 @@ import (
 )
 
 func TestGatewayJsonCbor(t *testing.T) {
+	tooling.LogTestGroup(t, GroupPathGateway)
+
 	fixture := car.MustOpenUnixfsCar("path_gateway_dag/gateway-json-cbor.car")
 
 	fileJSON := fixture.MustGetNode("ą", "ę", "t.json")
@@ -66,6 +69,8 @@ func TestGatewayJsonCbor(t *testing.T) {
 // ## Reading UnixFS (data encoded with dag-pb codec) as DAG-CBOR and DAG-JSON
 // ## (returns representation defined in https://ipld.io/specs/codecs/dag-pb/spec/#logical-format)
 func TestDagPbConversion(t *testing.T) {
+	tooling.LogTestGroup(t, GroupPathGateway)
+
 	fixture := car.MustOpenUnixfsCar("path_gateway_dag/gateway-json-cbor.car")
 
 	dir := fixture.MustGetRoot()
@@ -205,6 +210,8 @@ func TestDagPbConversion(t *testing.T) {
 // # Requesting CID with plain json (0x0200) and cbor (0x51) codecs
 // # (note these are not UnixFS, not DAG-* variants, just raw block identified by a CID with a special codec)
 func TestPlainCodec(t *testing.T) {
+	tooling.LogTestGroup(t, GroupPathGateway)
+
 	table := []struct {
 		Name        string
 		Format      string
@@ -308,6 +315,8 @@ func TestPlainCodec(t *testing.T) {
 
 // ## Pathing, traversal over DAG-JSON and DAG-CBOR
 func TestPathing(t *testing.T) {
+	tooling.LogTestGroup(t, GroupPathGateway)
+
 	dagJSONTraversal := car.MustOpenUnixfsCar("path_gateway_dag/dag-json-traversal.car").MustGetRoot()
 	dagCBORTraversal := car.MustOpenUnixfsCar("path_gateway_dag/dag-cbor-traversal.car").MustGetRoot()
 
@@ -381,6 +390,8 @@ func TestPathing(t *testing.T) {
 // ## NATIVE TESTS for DAG-JSON (0x0129) and DAG-CBOR (0x71):
 // ## DAG- regression tests for core behaviors when native DAG-(CBOR|JSON) is requested
 func TestNativeDag(t *testing.T) {
+	tooling.LogTestGroup(t, GroupPathGateway)
+
 	missingCID := car.RandomCID()
 
 	table := []struct {
@@ -570,6 +581,8 @@ func TestNativeDag(t *testing.T) {
 }
 
 func TestGatewayJSONCborAndIPNS(t *testing.T) {
+	tooling.LogTestGroup(t, GroupPathGateway)
+
 	ipnsIdDagJSON := "k51qzi5uqu5dhjghbwdvbo6mi40htrq6e2z4pwgp15pgv3ho1azvidttzh8yy2"
 	ipnsIdDagCBOR := "k51qzi5uqu5dghjous0agrwavl8vzl64xckoqzwqeqwudfr74kfd11zcyk3b7l"
 

--- a/tests/path_gateway_ipns_test.go
+++ b/tests/path_gateway_ipns_test.go
@@ -3,11 +3,14 @@ package tests
 import (
 	"testing"
 
+	"github.com/ipfs/gateway-conformance/tooling"
 	"github.com/ipfs/gateway-conformance/tooling/specs"
 	. "github.com/ipfs/gateway-conformance/tooling/test"
 )
 
 func TestRedirectCanonicalIPNS(t *testing.T) {
+	tooling.LogTestGroup(t, GroupPathGateway)
+
 	tests := SugarTests{
 		{
 			Name: "GET for /ipns/{b58-multihash-of-ed25519-key} redirects to /ipns/{cidv1-libp2p-key-base36}",

--- a/tests/path_gateway_ipns_test.go
+++ b/tests/path_gateway_ipns_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestRedirectCanonicalIPNS(t *testing.T) {
-	tooling.LogTestGroup(t, GroupPathGateway)
+	tooling.LogTestGroup(t, GroupIPNS)
 
 	tests := SugarTests{
 		{

--- a/tests/path_gateway_raw_test.go
+++ b/tests/path_gateway_raw_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestGatewayBlock(t *testing.T) {
-	tooling.LogTestGroup(t, GroupPathGateway)
+	tooling.LogTestGroup(t, GroupBlockCar)
 
 	fixture := car.MustOpenUnixfsCar("gateway-raw-block.car")
 

--- a/tests/path_gateway_raw_test.go
+++ b/tests/path_gateway_raw_test.go
@@ -5,12 +5,15 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/ipfs/gateway-conformance/tooling"
 	"github.com/ipfs/gateway-conformance/tooling/car"
 	"github.com/ipfs/gateway-conformance/tooling/specs"
 	. "github.com/ipfs/gateway-conformance/tooling/test"
 )
 
 func TestGatewayBlock(t *testing.T) {
+	tooling.LogTestGroup(t, GroupPathGateway)
+
 	fixture := car.MustOpenUnixfsCar("gateway-raw-block.car")
 
 	tests := SugarTests{

--- a/tests/path_gateway_tar_test.go
+++ b/tests/path_gateway_tar_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestTar(t *testing.T) {
-	tooling.LogTestGroup(t, GroupPathGateway)
+	tooling.LogTestGroup(t, GroupTar)
 
 	fixtureOutside := car.MustOpenUnixfsCar("path_gateway_tar/outside-root.car")
 	fixtureInside := car.MustOpenUnixfsCar("path_gateway_tar/inside-root.car")

--- a/tests/path_gateway_tar_test.go
+++ b/tests/path_gateway_tar_test.go
@@ -3,6 +3,7 @@ package tests
 import (
 	"testing"
 
+	"github.com/ipfs/gateway-conformance/tooling"
 	"github.com/ipfs/gateway-conformance/tooling/car"
 	. "github.com/ipfs/gateway-conformance/tooling/check"
 	"github.com/ipfs/gateway-conformance/tooling/specs"
@@ -11,6 +12,8 @@ import (
 )
 
 func TestTar(t *testing.T) {
+	tooling.LogTestGroup(t, GroupPathGateway)
+
 	fixtureOutside := car.MustOpenUnixfsCar("path_gateway_tar/outside-root.car")
 	fixtureInside := car.MustOpenUnixfsCar("path_gateway_tar/inside-root.car")
 

--- a/tests/path_gateway_unixfs_test.go
+++ b/tests/path_gateway_unixfs_test.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/ipfs/gateway-conformance/tooling"
 	"github.com/ipfs/gateway-conformance/tooling/car"
 	. "github.com/ipfs/gateway-conformance/tooling/check"
 	"github.com/ipfs/gateway-conformance/tooling/ipns"
@@ -13,6 +14,8 @@ import (
 )
 
 func TestUnixFSDirectoryListing(t *testing.T) {
+	tooling.LogTestGroup(t, GroupPathGateway)
+
 	fixture := car.MustOpenUnixfsCar("dir_listing/fixtures.car")
 	root := fixture.MustGetNode()
 	file := fixture.MustGetNode("ą", "ę", "file-źł.txt")
@@ -76,6 +79,8 @@ func TestUnixFSDirectoryListing(t *testing.T) {
 }
 
 func TestGatewayCache(t *testing.T) {
+	tooling.LogTestGroup(t, GroupPathGateway)
+
 	fixture := car.MustOpenUnixfsCar("gateway-cache/fixtures.car")
 
 	tests := SugarTests{
@@ -308,6 +313,8 @@ func TestGatewayCache(t *testing.T) {
 }
 
 func TestGatewayCacheWithIPNS(t *testing.T) {
+	tooling.LogTestGroup(t, GroupPathGateway)
+
 	fixture := car.MustOpenUnixfsCar("gateway-cache/fixtures.car")
 	ipns := ipns.MustOpenIPNSRecordWithKey("gateway-cache/k51qzi5uqu5dlxdsdu5fpuu7h69wu4ohp32iwm9pdt9nq3y5rpn3ln9j12zfhe.ipns-record")
 	ipnsKey := ipns.Key()
@@ -404,6 +411,8 @@ func TestGatewayCacheWithIPNS(t *testing.T) {
 }
 
 func TestGatewaySymlink(t *testing.T) {
+	tooling.LogTestGroup(t, GroupPathGateway)
+
 	fixture := car.MustOpenUnixfsCar("path_gateway_unixfs/symlink.car")
 	rootDirCID := fixture.MustGetCid()
 
@@ -443,6 +452,8 @@ func TestGatewaySymlink(t *testing.T) {
 }
 
 func TestGatewayUnixFSFileRanges(t *testing.T) {
+	tooling.LogTestGroup(t, GroupPathGateway)
+
 	// Multi-range requests MUST conform to the HTTP semantics. The server does not
 	// need to be able to support returning multiple ranges. However, it must respond
 	// correctly.

--- a/tests/path_gateway_unixfs_test.go
+++ b/tests/path_gateway_unixfs_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func TestUnixFSDirectoryListing(t *testing.T) {
-	tooling.LogTestGroup(t, GroupPathGateway)
+	tooling.LogTestGroup(t, GroupUnixFS)
 
 	fixture := car.MustOpenUnixfsCar("dir_listing/fixtures.car")
 	root := fixture.MustGetNode()
@@ -79,8 +79,6 @@ func TestUnixFSDirectoryListing(t *testing.T) {
 }
 
 func TestGatewayCache(t *testing.T) {
-	tooling.LogTestGroup(t, GroupPathGateway)
-
 	fixture := car.MustOpenUnixfsCar("gateway-cache/fixtures.car")
 
 	tests := SugarTests{
@@ -313,7 +311,7 @@ func TestGatewayCache(t *testing.T) {
 }
 
 func TestGatewayCacheWithIPNS(t *testing.T) {
-	tooling.LogTestGroup(t, GroupPathGateway)
+	tooling.LogTestGroup(t, GroupIPNS)
 
 	fixture := car.MustOpenUnixfsCar("gateway-cache/fixtures.car")
 	ipns := ipns.MustOpenIPNSRecordWithKey("gateway-cache/k51qzi5uqu5dlxdsdu5fpuu7h69wu4ohp32iwm9pdt9nq3y5rpn3ln9j12zfhe.ipns-record")
@@ -411,8 +409,6 @@ func TestGatewayCacheWithIPNS(t *testing.T) {
 }
 
 func TestGatewaySymlink(t *testing.T) {
-	tooling.LogTestGroup(t, GroupPathGateway)
-
 	fixture := car.MustOpenUnixfsCar("path_gateway_unixfs/symlink.car")
 	rootDirCID := fixture.MustGetCid()
 
@@ -452,7 +448,7 @@ func TestGatewaySymlink(t *testing.T) {
 }
 
 func TestGatewayUnixFSFileRanges(t *testing.T) {
-	tooling.LogTestGroup(t, GroupPathGateway)
+	tooling.LogTestGroup(t, GroupUnixFS)
 
 	// Multi-range requests MUST conform to the HTTP semantics. The server does not
 	// need to be able to support returning multiple ranges. However, it must respond

--- a/tests/redirects_file_test.go
+++ b/tests/redirects_file_test.go
@@ -4,6 +4,7 @@ import (
 	"net/url"
 	"testing"
 
+	"github.com/ipfs/gateway-conformance/tooling"
 	"github.com/ipfs/gateway-conformance/tooling/car"
 	. "github.com/ipfs/gateway-conformance/tooling/check"
 	"github.com/ipfs/gateway-conformance/tooling/dnslink"
@@ -235,6 +236,7 @@ func TestRedirectsFileSupport(t *testing.T) {
 }
 
 func TestRedirectsFileSupportWithDNSLink(t *testing.T) {
+	tooling.LogTestGroup(t, GroupDNSLink)
 	dnsLinks := dnslink.MustOpenDNSLink("redirects_file/dnslink.yml")
 	dnsLink := dnsLinks.MustGet("custom-dnslink")
 

--- a/tests/subdomain_gateway_ipfs_test.go
+++ b/tests/subdomain_gateway_ipfs_test.go
@@ -4,6 +4,7 @@ import (
 	"net/url"
 	"testing"
 
+	"github.com/ipfs/gateway-conformance/tooling"
 	"github.com/ipfs/gateway-conformance/tooling/car"
 	. "github.com/ipfs/gateway-conformance/tooling/check"
 	"github.com/ipfs/gateway-conformance/tooling/helpers"
@@ -12,6 +13,8 @@ import (
 )
 
 func TestUnixFSDirectoryListingOnSubdomainGateway(t *testing.T) {
+	tooling.LogTestGroup(t, GroupSubdomainGateway)
+
 	fixture := car.MustOpenUnixfsCar("dir_listing/fixtures.car")
 	root := fixture.MustGetNode()
 	file := fixture.MustGetNode("ą", "ę", "file-źł.txt")
@@ -105,6 +108,8 @@ func TestUnixFSDirectoryListingOnSubdomainGateway(t *testing.T) {
 }
 
 func TestGatewaySubdomains(t *testing.T) {
+	tooling.LogTestGroup(t, GroupSubdomainGateway)
+
 	fixture := car.MustOpenUnixfsCar("subdomain_gateway/fixtures.car")
 
 	CIDVal := string(fixture.MustGetRawData("hello-CIDv1")) // hello

--- a/tests/subdomain_gateway_ipfs_test.go
+++ b/tests/subdomain_gateway_ipfs_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestUnixFSDirectoryListingOnSubdomainGateway(t *testing.T) {
-	tooling.LogTestGroup(t, GroupSubdomainGateway)
+	tooling.LogTestGroup(t, GroupUnixFS)
 
 	fixture := car.MustOpenUnixfsCar("dir_listing/fixtures.car")
 	root := fixture.MustGetNode()
@@ -108,7 +108,7 @@ func TestUnixFSDirectoryListingOnSubdomainGateway(t *testing.T) {
 }
 
 func TestGatewaySubdomains(t *testing.T) {
-	tooling.LogTestGroup(t, GroupSubdomainGateway)
+	tooling.LogTestGroup(t, GroupSubdomains)
 
 	fixture := car.MustOpenUnixfsCar("subdomain_gateway/fixtures.car")
 

--- a/tests/subdomain_gateway_ipns_test.go
+++ b/tests/subdomain_gateway_ipns_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 func TestGatewaySubdomainAndIPNS(t *testing.T) {
-	tooling.LogTestGroup(t, GroupSubdomainGateway)
+	tooling.LogTestGroup(t, GroupSubdomains)
 
 	tests := SugarTests{}
 
@@ -162,7 +162,7 @@ func TestGatewaySubdomainAndIPNS(t *testing.T) {
 }
 
 func TestSubdomainGatewayDNSLinkInlining(t *testing.T) {
-	tooling.LogTestGroup(t, GroupSubdomainGateway)
+	tooling.LogTestGroup(t, GroupSubdomains)
 
 	tests := SugarTests{}
 

--- a/tests/subdomain_gateway_ipns_test.go
+++ b/tests/subdomain_gateway_ipns_test.go
@@ -4,6 +4,7 @@ import (
 	"net/url"
 	"testing"
 
+	"github.com/ipfs/gateway-conformance/tooling"
 	"github.com/ipfs/gateway-conformance/tooling/car"
 	"github.com/ipfs/gateway-conformance/tooling/dnslink"
 	"github.com/ipfs/gateway-conformance/tooling/helpers"
@@ -15,6 +16,8 @@ import (
 )
 
 func TestGatewaySubdomainAndIPNS(t *testing.T) {
+	tooling.LogTestGroup(t, GroupSubdomainGateway)
+
 	tests := SugarTests{}
 
 	rsaFixture := ipns.MustOpenIPNSRecordWithKey("subdomain_gateway/QmVujd5Vb7moysJj8itnGufN7MEtPRCNHkKpNuA4onsRa3.ipns-record")
@@ -159,6 +162,8 @@ func TestGatewaySubdomainAndIPNS(t *testing.T) {
 }
 
 func TestSubdomainGatewayDNSLinkInlining(t *testing.T) {
+	tooling.LogTestGroup(t, GroupSubdomainGateway)
+
 	tests := SugarTests{}
 
 	// We're going to run the same test against multiple gateways (localhost, and a subdomain gateway)

--- a/tests/trustless_gateway_car_test.go
+++ b/tests/trustless_gateway_car_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestTrustlessCarPathing(t *testing.T) {
-	tooling.LogTestGroup(t, GroupTrustlessGateway)
+	tooling.LogTestGroup(t, GroupBlockCar)
 
 	subdirTwoSingleBlockFilesFixture := car.MustOpenUnixfsCar("trustless_gateway_car/subdir-with-two-single-block-files.car")
 	singleLayerHamtMultiBlockFilesFixture := car.MustOpenUnixfsCar("trustless_gateway_car/single-layer-hamt-with-multi-block-files.car")
@@ -121,7 +121,7 @@ func TestTrustlessCarPathing(t *testing.T) {
 }
 
 func TestTrustlessCarDagScopeBlock(t *testing.T) {
-	tooling.LogTestGroup(t, GroupTrustlessGateway)
+	tooling.LogTestGroup(t, GroupBlockCar)
 
 	subdirTwoSingleBlockFilesFixture := car.MustOpenUnixfsCar("trustless_gateway_car/subdir-with-two-single-block-files.car")
 	singleLayerHamtMultiBlockFilesFixture := car.MustOpenUnixfsCar("trustless_gateway_car/single-layer-hamt-with-multi-block-files.car")
@@ -206,7 +206,7 @@ func TestTrustlessCarDagScopeBlock(t *testing.T) {
 }
 
 func TestTrustlessCarDagScopeEntity(t *testing.T) {
-	tooling.LogTestGroup(t, GroupTrustlessGateway)
+	tooling.LogTestGroup(t, GroupBlockCar)
 
 	subdirTwoSingleBlockFilesFixture := car.MustOpenUnixfsCar("trustless_gateway_car/subdir-with-two-single-block-files.car")
 	singleLayerHamtMultiBlockFilesFixture := car.MustOpenUnixfsCar("trustless_gateway_car/single-layer-hamt-with-multi-block-files.car")
@@ -342,7 +342,7 @@ func TestTrustlessCarDagScopeEntity(t *testing.T) {
 }
 
 func TestTrustlessCarDagScopeAll(t *testing.T) {
-	tooling.LogTestGroup(t, GroupTrustlessGateway)
+	tooling.LogTestGroup(t, GroupBlockCar)
 
 	subdirWithMixedBlockFiles := car.MustOpenUnixfsCar("trustless_gateway_car/subdir-with-mixed-block-files.car")
 
@@ -407,7 +407,7 @@ func TestTrustlessCarDagScopeAll(t *testing.T) {
 }
 
 func TestTrustlessCarEntityBytes(t *testing.T) {
-	tooling.LogTestGroup(t, GroupTrustlessGateway)
+	tooling.LogTestGroup(t, GroupBlockCar)
 
 	singleLayerHamtMultiBlockFilesFixture := car.MustOpenUnixfsCar("trustless_gateway_car/single-layer-hamt-with-multi-block-files.car")
 	subdirWithMixedBlockFiles := car.MustOpenUnixfsCar("trustless_gateway_car/subdir-with-mixed-block-files.car")
@@ -669,7 +669,7 @@ func TestTrustlessCarEntityBytes(t *testing.T) {
 }
 
 func TestTrustlessCarOrderAndDuplicates(t *testing.T) {
-	tooling.LogTestGroup(t, GroupTrustlessGateway)
+	tooling.LogTestGroup(t, GroupBlockCar)
 
 	dirWithDuplicateFiles := car.MustOpenUnixfsCar("trustless_gateway_car/dir-with-duplicate-files.car")
 	// This array is defined at the SPEC level and should not depend on library behavior

--- a/tests/trustless_gateway_car_test.go
+++ b/tests/trustless_gateway_car_test.go
@@ -3,6 +3,7 @@ package tests
 import (
 	"testing"
 
+	"github.com/ipfs/gateway-conformance/tooling"
 	"github.com/ipfs/gateway-conformance/tooling/car"
 	. "github.com/ipfs/gateway-conformance/tooling/check"
 	"github.com/ipfs/gateway-conformance/tooling/helpers"
@@ -11,6 +12,8 @@ import (
 )
 
 func TestTrustlessCarPathing(t *testing.T) {
+	tooling.LogTestGroup(t, GroupTrustlessGateway)
+
 	subdirTwoSingleBlockFilesFixture := car.MustOpenUnixfsCar("trustless_gateway_car/subdir-with-two-single-block-files.car")
 	singleLayerHamtMultiBlockFilesFixture := car.MustOpenUnixfsCar("trustless_gateway_car/single-layer-hamt-with-multi-block-files.car")
 	dirWithDagCborWithLinksFixture := car.MustOpenUnixfsCar("trustless_gateway_car/dir-with-dag-cbor-with-links.car")
@@ -118,6 +121,8 @@ func TestTrustlessCarPathing(t *testing.T) {
 }
 
 func TestTrustlessCarDagScopeBlock(t *testing.T) {
+	tooling.LogTestGroup(t, GroupTrustlessGateway)
+
 	subdirTwoSingleBlockFilesFixture := car.MustOpenUnixfsCar("trustless_gateway_car/subdir-with-two-single-block-files.car")
 	singleLayerHamtMultiBlockFilesFixture := car.MustOpenUnixfsCar("trustless_gateway_car/single-layer-hamt-with-multi-block-files.car")
 
@@ -201,6 +206,8 @@ func TestTrustlessCarDagScopeBlock(t *testing.T) {
 }
 
 func TestTrustlessCarDagScopeEntity(t *testing.T) {
+	tooling.LogTestGroup(t, GroupTrustlessGateway)
+
 	subdirTwoSingleBlockFilesFixture := car.MustOpenUnixfsCar("trustless_gateway_car/subdir-with-two-single-block-files.car")
 	singleLayerHamtMultiBlockFilesFixture := car.MustOpenUnixfsCar("trustless_gateway_car/single-layer-hamt-with-multi-block-files.car")
 	subdirWithMixedBlockFiles := car.MustOpenUnixfsCar("trustless_gateway_car/subdir-with-mixed-block-files.car")
@@ -335,6 +342,8 @@ func TestTrustlessCarDagScopeEntity(t *testing.T) {
 }
 
 func TestTrustlessCarDagScopeAll(t *testing.T) {
+	tooling.LogTestGroup(t, GroupTrustlessGateway)
+
 	subdirWithMixedBlockFiles := car.MustOpenUnixfsCar("trustless_gateway_car/subdir-with-mixed-block-files.car")
 
 	tests := SugarTests{
@@ -398,6 +407,8 @@ func TestTrustlessCarDagScopeAll(t *testing.T) {
 }
 
 func TestTrustlessCarEntityBytes(t *testing.T) {
+	tooling.LogTestGroup(t, GroupTrustlessGateway)
+
 	singleLayerHamtMultiBlockFilesFixture := car.MustOpenUnixfsCar("trustless_gateway_car/single-layer-hamt-with-multi-block-files.car")
 	subdirWithMixedBlockFiles := car.MustOpenUnixfsCar("trustless_gateway_car/subdir-with-mixed-block-files.car")
 	missingBlockFixture := car.MustOpenUnixfsCar("trustless_gateway_car/file-3k-and-3-blocks-missing-block.car")
@@ -658,6 +669,8 @@ func TestTrustlessCarEntityBytes(t *testing.T) {
 }
 
 func TestTrustlessCarOrderAndDuplicates(t *testing.T) {
+	tooling.LogTestGroup(t, GroupTrustlessGateway)
+
 	dirWithDuplicateFiles := car.MustOpenUnixfsCar("trustless_gateway_car/dir-with-duplicate-files.car")
 	// This array is defined at the SPEC level and should not depend on library behavior
 	// See the recipe for `dir-with-duplicate-files.car`

--- a/tests/trustless_gateway_ipns_test.go
+++ b/tests/trustless_gateway_ipns_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestGatewayIPNSRecord(t *testing.T) {
-	tooling.LogTestGroup(t, GroupTrustlessGateway)
+	tooling.LogTestGroup(t, GroupIPNS)
 
 	fixture := car.MustOpenUnixfsCar("ipns_records/fixtures.car")
 	file := fixture.MustGetRoot()

--- a/tests/trustless_gateway_ipns_test.go
+++ b/tests/trustless_gateway_ipns_test.go
@@ -3,6 +3,7 @@ package tests
 import (
 	"testing"
 
+	"github.com/ipfs/gateway-conformance/tooling"
 	"github.com/ipfs/gateway-conformance/tooling/car"
 	. "github.com/ipfs/gateway-conformance/tooling/ipns"
 	"github.com/ipfs/gateway-conformance/tooling/specs"
@@ -10,6 +11,8 @@ import (
 )
 
 func TestGatewayIPNSRecord(t *testing.T) {
+	tooling.LogTestGroup(t, GroupTrustlessGateway)
+
 	fixture := car.MustOpenUnixfsCar("ipns_records/fixtures.car")
 	file := fixture.MustGetRoot()
 	fileCID := file.Cid()

--- a/tests/trustless_gateway_raw_test.go
+++ b/tests/trustless_gateway_raw_test.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/ipfs/gateway-conformance/tooling"
 	"github.com/ipfs/gateway-conformance/tooling/car"
 	. "github.com/ipfs/gateway-conformance/tooling/check"
 	"github.com/ipfs/gateway-conformance/tooling/specs"
@@ -12,6 +13,8 @@ import (
 )
 
 func TestTrustlessRaw(t *testing.T) {
+	tooling.LogTestGroup(t, GroupTrustlessGateway)
+
 	fixture := car.MustOpenUnixfsCar("gateway-raw-block.car")
 
 	tests := SugarTests{
@@ -128,6 +131,8 @@ func TestTrustlessRaw(t *testing.T) {
 }
 
 func TestTrustlessRawRanges(t *testing.T) {
+	tooling.LogTestGroup(t, GroupTrustlessGateway)
+
 	// Multi-range requests MUST conform to the HTTP semantics. The server does not
 	// need to be able to support returning multiple ranges. However, it must respond
 	// correctly.

--- a/tests/trustless_gateway_raw_test.go
+++ b/tests/trustless_gateway_raw_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestTrustlessRaw(t *testing.T) {
-	tooling.LogTestGroup(t, GroupTrustlessGateway)
+	tooling.LogTestGroup(t, GroupBlockCar)
 
 	fixture := car.MustOpenUnixfsCar("gateway-raw-block.car")
 
@@ -131,7 +131,7 @@ func TestTrustlessRaw(t *testing.T) {
 }
 
 func TestTrustlessRawRanges(t *testing.T) {
-	tooling.LogTestGroup(t, GroupTrustlessGateway)
+	tooling.LogTestGroup(t, GroupBlockCar)
 
 	// Multi-range requests MUST conform to the HTTP semantics. The server does not
 	// need to be able to support returning multiple ranges. However, it must respond

--- a/tooling/metadata.go
+++ b/tooling/metadata.go
@@ -18,6 +18,16 @@ func LogMetadata(t *testing.T, value interface{}) {
 	t.Logf("--- META: %s", string(jsonValue))
 }
 
+func LogTestGroup(t *testing.T, name string) {
+	t.Helper()
+
+	LogMetadata(t, struct {
+		Group string `json:"group"`
+	}{
+		Group: name,
+	})
+}
+
 func LogVersion(t *testing.T) {
 	LogMetadata(t, struct {
 		Version string `json:"version"`


### PR DESCRIPTION
contributes to #123 

Add a "User Taxonomy" different from the specs. This will be used in gateway checker and other user-facing tooling.

- [x] Introduce API
- [x] Add "most" tests to groups
- [ ] Test with gateway checker

