### PR TITLE
feat: add specs and user taxonomies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Output Github's workflow URL with metadata. [PR](https://github.com/ipfs/gateway-conformance/pull/145)
 - Basic Dashboard Output with content generation. [PR](https://github.com/ipfs/gateway-conformance/pull/152)
 - Test Group Metadata on Tests. [PR](https://github.com/ipfs/gateway-conformance/pull/156)
+- Specs Metadata on Tests. [PR](https://github.com/ipfs/gateway-conformance/pull/159)
 
 ## [0.3.0] - 2023-07-31
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Metadata logging used to associate tests with custom data like versions, specs identifiers, etc.
 - Output Github's workflow URL with metadata. [PR](https://github.com/ipfs/gateway-conformance/pull/145)
 - Basic Dashboard Output with content generation. [PR](https://github.com/ipfs/gateway-conformance/pull/152)
+- Test Group Metadata on Tests. [PR](https://github.com/ipfs/gateway-conformance/pull/156)
 
 ## [0.3.0] - 2023-07-31
 ### Added

--- a/aggregate-into-table.js
+++ b/aggregate-into-table.js
@@ -23,7 +23,7 @@ delete metadata[TestMetadata]; // Extract TestMetadata which is a special case
 // generate groups: an array of {group, key} objects
 // where group is the group name (or undefined), and key is the test key name (or undefined)
 // It represents the table leftmost column.
-// 
+//
 // Group1
 //  Group1 - Test1
 //  Group1 - Test2
@@ -69,7 +69,7 @@ groups.sort((a, b) => {
 // generate a table
 const columns = [];
 
-// add the leading column ("gateway", "version", "key1", "key2", ... "keyN")
+// add the leading column ("gateway", "version", "group1", "test11", ... "test42")
 const leading = ["gateway", "version"];
 groups.forEach(({ group, key }) => {
     if (key === undefined) {
@@ -77,10 +77,18 @@ groups.forEach(({ group, key }) => {
         return;
     }
 
-    const m = metadata[key];
-
     // Skip the "Test" prefix
     let niceKey = key.replace(/^Test/, '');
+
+    const m = metadata[key];
+    if (m.specs && m.specs.length > 0) {
+        if (m.specs.length === 1) {
+            niceKey = `[${niceKey}](https://${m.specs[0]})`
+        } else {
+            const urls = m.specs.map((url, index) => `[${index}](https://${url})`);
+            niceKey = `${niceKey} (${urls.join(', ')})`;
+        }
+    }
 
     leading.push(niceKey);
 });

--- a/tests/dnslink_gateway_test.go
+++ b/tests/dnslink_gateway_test.go
@@ -4,6 +4,7 @@ import (
 	"net/url"
 	"testing"
 
+	"github.com/ipfs/gateway-conformance/tooling"
 	"github.com/ipfs/gateway-conformance/tooling/car"
 	. "github.com/ipfs/gateway-conformance/tooling/check"
 	"github.com/ipfs/gateway-conformance/tooling/dnslink"
@@ -14,6 +15,8 @@ import (
 )
 
 func TestDNSLinkGatewayUnixFSDirectoryListing(t *testing.T) {
+	tooling.LogTestGroup(t, GroupDNSLink)
+
 	fixture := car.MustOpenUnixfsCar("dir_listing/fixtures.car")
 	file := fixture.MustGetNode("ą", "ę", "file-źł.txt")
 

--- a/tests/metadata_test.go
+++ b/tests/metadata_test.go
@@ -4,12 +4,23 @@ import (
 	"testing"
 
 	"github.com/ipfs/gateway-conformance/tooling"
+	"github.com/ipfs/gateway-conformance/tooling/test"
 )
+
+func logGatewayURL(t *testing.T) {
+	tooling.LogMetadata(t, struct {
+		GatewayURL          string `json:"gateway_url"`
+		SubdomainGatewayURL string `json:"subdomain_gateway_url"`
+	}{
+		GatewayURL:          test.GatewayURL,
+		SubdomainGatewayURL: test.SubdomainGatewayURL,
+	})
+}
 
 func TestMetadata(t *testing.T) {
 	tooling.LogVersion(t)
 	tooling.LogJobURL(t)
-	tooling.LogGatewayURL(t)
+	logGatewayURL(t)
 }
 
 const (

--- a/tests/metadata_test.go
+++ b/tests/metadata_test.go
@@ -13,9 +13,12 @@ func TestMetadata(t *testing.T) {
 }
 
 const (
-	GroupTrustlessGateway = "Trustless Gateway"
-	GroupPathGateway      = "Path Gateway"
-	GroupSubdomainGateway = "Subdomain Gateway"
-	GroupCORS             = "CORS"
-	GroupIPNS             = "IPNS"
+	GroupSubdomains = "Subdomains"
+	GroupCORS       = "CORS"
+	GroupIPNS       = "IPNS"
+	GroupDNSLink    = "DNSLink"
+	GroupJSONCbor   = "JSON-CBOR"
+	GroupBlockCar   = "Block-CAR"
+	GroupTar        = "Tar"
+	GroupUnixFS     = "UnixFS"
 )

--- a/tests/metadata_test.go
+++ b/tests/metadata_test.go
@@ -11,3 +11,11 @@ func TestMetadata(t *testing.T) {
 	tooling.LogJobURL(t)
 	tooling.LogGatewayURL(t)
 }
+
+const (
+	GroupTrustlessGateway = "Trustless Gateway"
+	GroupPathGateway      = "Path Gateway"
+	GroupSubdomainGateway = "Subdomain Gateway"
+	GroupCORS             = "CORS"
+	GroupIPNS             = "IPNS"
+)

--- a/tests/path_gateway_cors_test.go
+++ b/tests/path_gateway_cors_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestCors(t *testing.T) {
-	tooling.LogTestGroup(t, GroupPathGateway)
+	tooling.LogTestGroup(t, GroupCORS)
 
 	cidHello := "bafkqabtimvwgy3yk" // hello
 

--- a/tests/path_gateway_cors_test.go
+++ b/tests/path_gateway_cors_test.go
@@ -3,11 +3,14 @@ package tests
 import (
 	"testing"
 
+	"github.com/ipfs/gateway-conformance/tooling"
 	"github.com/ipfs/gateway-conformance/tooling/specs"
 	. "github.com/ipfs/gateway-conformance/tooling/test"
 )
 
 func TestCors(t *testing.T) {
+	tooling.LogTestGroup(t, GroupPathGateway)
+
 	cidHello := "bafkqabtimvwgy3yk" // hello
 
 	tests := SugarTests{

--- a/tests/path_gateway_dag_test.go
+++ b/tests/path_gateway_dag_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestGatewayJsonCbor(t *testing.T) {
-	tooling.LogTestGroup(t, GroupPathGateway)
+	tooling.LogTestGroup(t, GroupJSONCbor)
 
 	fixture := car.MustOpenUnixfsCar("path_gateway_dag/gateway-json-cbor.car")
 
@@ -69,7 +69,7 @@ func TestGatewayJsonCbor(t *testing.T) {
 // ## Reading UnixFS (data encoded with dag-pb codec) as DAG-CBOR and DAG-JSON
 // ## (returns representation defined in https://ipld.io/specs/codecs/dag-pb/spec/#logical-format)
 func TestDagPbConversion(t *testing.T) {
-	tooling.LogTestGroup(t, GroupPathGateway)
+	tooling.LogTestGroup(t, GroupJSONCbor)
 
 	fixture := car.MustOpenUnixfsCar("path_gateway_dag/gateway-json-cbor.car")
 
@@ -210,7 +210,7 @@ func TestDagPbConversion(t *testing.T) {
 // # Requesting CID with plain json (0x0200) and cbor (0x51) codecs
 // # (note these are not UnixFS, not DAG-* variants, just raw block identified by a CID with a special codec)
 func TestPlainCodec(t *testing.T) {
-	tooling.LogTestGroup(t, GroupPathGateway)
+	tooling.LogTestGroup(t, GroupJSONCbor)
 
 	table := []struct {
 		Name        string
@@ -315,7 +315,7 @@ func TestPlainCodec(t *testing.T) {
 
 // ## Pathing, traversal over DAG-JSON and DAG-CBOR
 func TestPathing(t *testing.T) {
-	tooling.LogTestGroup(t, GroupPathGateway)
+	tooling.LogTestGroup(t, GroupJSONCbor)
 
 	dagJSONTraversal := car.MustOpenUnixfsCar("path_gateway_dag/dag-json-traversal.car").MustGetRoot()
 	dagCBORTraversal := car.MustOpenUnixfsCar("path_gateway_dag/dag-cbor-traversal.car").MustGetRoot()
@@ -390,7 +390,7 @@ func TestPathing(t *testing.T) {
 // ## NATIVE TESTS for DAG-JSON (0x0129) and DAG-CBOR (0x71):
 // ## DAG- regression tests for core behaviors when native DAG-(CBOR|JSON) is requested
 func TestNativeDag(t *testing.T) {
-	tooling.LogTestGroup(t, GroupPathGateway)
+	tooling.LogTestGroup(t, GroupJSONCbor)
 
 	missingCID := car.RandomCID()
 
@@ -581,7 +581,7 @@ func TestNativeDag(t *testing.T) {
 }
 
 func TestGatewayJSONCborAndIPNS(t *testing.T) {
-	tooling.LogTestGroup(t, GroupPathGateway)
+	tooling.LogTestGroup(t, GroupIPNS)
 
 	ipnsIdDagJSON := "k51qzi5uqu5dhjghbwdvbo6mi40htrq6e2z4pwgp15pgv3ho1azvidttzh8yy2"
 	ipnsIdDagCBOR := "k51qzi5uqu5dghjous0agrwavl8vzl64xckoqzwqeqwudfr74kfd11zcyk3b7l"

--- a/tests/path_gateway_dag_test.go
+++ b/tests/path_gateway_dag_test.go
@@ -42,6 +42,7 @@ func TestGatewayJsonCbor(t *testing.T) {
 		},
 		{
 			Name: "GET UnixFS file with JSON bytes is returned with application/json Content-Type - with headers",
+			Spec: "specs.ipfs.tech/http-gateways/path-gateway/#accept-request-header",
 			Hint: `
 			## Quick regression check for JSON stored on UnixFS:
 			## it has nothing to do with DAG-JSON and JSON codecs,
@@ -478,7 +479,7 @@ func TestNativeDag(t *testing.T) {
 				Response: Expect().
 					Headers(
 						Header("Content-Type").Hint("expected Content-Type").Equals("application/vnd.ipld.dag-{{format}}", row.Format),
-						Header("Content-Length").Hint("includes Content-Length").Equals("{{length}}", len(dagTraversal.RawData())),
+						Header("Content-Length").Spec("specs.ipfs.tech/http-gateways/path-gateway/#content-disposition-response-header").Hint("includes Content-Length").Equals("{{length}}", len(dagTraversal.RawData())),
 						Header("Content-Disposition").Hint("includes Content-Disposition").Contains(`{{disposition}}; filename="{{cid}}.{{format}}"`, row.Disposition, dagTraversalCID, row.Format),
 						Header("X-Content-Type-Options").Hint("includes nosniff hint").Contains("nosniff"),
 					),
@@ -552,6 +553,7 @@ func TestNativeDag(t *testing.T) {
 			},
 			{
 				Name: Fmt("HEAD {{name}} with only-if-cached for missing block returns HTTP 412 Precondition Failed", row.Name),
+				Spec: "specs.ipfs.tech/http-gateways/path-gateway/#only-if-cached",
 				Request: Request().
 					Path("/ipfs/{{cid}}", missingCID).
 					Header("Cache-Control", "only-if-cached").

--- a/tests/path_gateway_dag_test.go
+++ b/tests/path_gateway_dag_test.go
@@ -3,6 +3,7 @@ package tests
 import (
 	"testing"
 
+	"github.com/ipfs/gateway-conformance/tooling"
 	"github.com/ipfs/gateway-conformance/tooling/car"
 	. "github.com/ipfs/gateway-conformance/tooling/check"
 	"github.com/ipfs/gateway-conformance/tooling/ipns"
@@ -12,6 +13,8 @@ import (
 )
 
 func TestGatewayJsonCbor(t *testing.T) {
+	tooling.LogTestGroup(t, GroupPathGateway)
+
 	fixture := car.MustOpenUnixfsCar("path_gateway_dag/gateway-json-cbor.car")
 
 	fileJSON := fixture.MustGetNode("ą", "ę", "t.json")
@@ -66,6 +69,8 @@ func TestGatewayJsonCbor(t *testing.T) {
 // ## Reading UnixFS (data encoded with dag-pb codec) as DAG-CBOR and DAG-JSON
 // ## (returns representation defined in https://ipld.io/specs/codecs/dag-pb/spec/#logical-format)
 func TestDagPbConversion(t *testing.T) {
+	tooling.LogTestGroup(t, GroupPathGateway)
+
 	fixture := car.MustOpenUnixfsCar("path_gateway_dag/gateway-json-cbor.car")
 
 	dir := fixture.MustGetRoot()
@@ -205,6 +210,8 @@ func TestDagPbConversion(t *testing.T) {
 // # Requesting CID with plain json (0x0200) and cbor (0x51) codecs
 // # (note these are not UnixFS, not DAG-* variants, just raw block identified by a CID with a special codec)
 func TestPlainCodec(t *testing.T) {
+	tooling.LogTestGroup(t, GroupPathGateway)
+
 	table := []struct {
 		Name        string
 		Format      string
@@ -308,6 +315,8 @@ func TestPlainCodec(t *testing.T) {
 
 // ## Pathing, traversal over DAG-JSON and DAG-CBOR
 func TestPathing(t *testing.T) {
+	tooling.LogTestGroup(t, GroupPathGateway)
+
 	dagJSONTraversal := car.MustOpenUnixfsCar("path_gateway_dag/dag-json-traversal.car").MustGetRoot()
 	dagCBORTraversal := car.MustOpenUnixfsCar("path_gateway_dag/dag-cbor-traversal.car").MustGetRoot()
 
@@ -381,6 +390,8 @@ func TestPathing(t *testing.T) {
 // ## NATIVE TESTS for DAG-JSON (0x0129) and DAG-CBOR (0x71):
 // ## DAG- regression tests for core behaviors when native DAG-(CBOR|JSON) is requested
 func TestNativeDag(t *testing.T) {
+	tooling.LogTestGroup(t, GroupPathGateway)
+
 	missingCID := car.RandomCID()
 
 	table := []struct {
@@ -570,6 +581,8 @@ func TestNativeDag(t *testing.T) {
 }
 
 func TestGatewayJSONCborAndIPNS(t *testing.T) {
+	tooling.LogTestGroup(t, GroupPathGateway)
+
 	ipnsIdDagJSON := "k51qzi5uqu5dhjghbwdvbo6mi40htrq6e2z4pwgp15pgv3ho1azvidttzh8yy2"
 	ipnsIdDagCBOR := "k51qzi5uqu5dghjous0agrwavl8vzl64xckoqzwqeqwudfr74kfd11zcyk3b7l"
 

--- a/tests/path_gateway_ipns_test.go
+++ b/tests/path_gateway_ipns_test.go
@@ -3,11 +3,14 @@ package tests
 import (
 	"testing"
 
+	"github.com/ipfs/gateway-conformance/tooling"
 	"github.com/ipfs/gateway-conformance/tooling/specs"
 	. "github.com/ipfs/gateway-conformance/tooling/test"
 )
 
 func TestRedirectCanonicalIPNS(t *testing.T) {
+	tooling.LogTestGroup(t, GroupPathGateway)
+
 	tests := SugarTests{
 		{
 			Name: "GET for /ipns/{b58-multihash-of-ed25519-key} redirects to /ipns/{cidv1-libp2p-key-base36}",

--- a/tests/path_gateway_ipns_test.go
+++ b/tests/path_gateway_ipns_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestRedirectCanonicalIPNS(t *testing.T) {
-	tooling.LogTestGroup(t, GroupPathGateway)
+	tooling.LogTestGroup(t, GroupIPNS)
 
 	tests := SugarTests{
 		{

--- a/tests/path_gateway_raw_test.go
+++ b/tests/path_gateway_raw_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestGatewayBlock(t *testing.T) {
-	tooling.LogTestGroup(t, GroupPathGateway)
+	tooling.LogTestGroup(t, GroupBlockCar)
 
 	fixture := car.MustOpenUnixfsCar("gateway-raw-block.car")
 

--- a/tests/path_gateway_raw_test.go
+++ b/tests/path_gateway_raw_test.go
@@ -5,12 +5,15 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/ipfs/gateway-conformance/tooling"
 	"github.com/ipfs/gateway-conformance/tooling/car"
 	"github.com/ipfs/gateway-conformance/tooling/specs"
 	. "github.com/ipfs/gateway-conformance/tooling/test"
 )
 
 func TestGatewayBlock(t *testing.T) {
+	tooling.LogTestGroup(t, GroupPathGateway)
+
 	fixture := car.MustOpenUnixfsCar("gateway-raw-block.car")
 
 	tests := SugarTests{

--- a/tests/path_gateway_tar_test.go
+++ b/tests/path_gateway_tar_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestTar(t *testing.T) {
-	tooling.LogTestGroup(t, GroupPathGateway)
+	tooling.LogTestGroup(t, GroupTar)
 
 	fixtureOutside := car.MustOpenUnixfsCar("path_gateway_tar/outside-root.car")
 	fixtureInside := car.MustOpenUnixfsCar("path_gateway_tar/inside-root.car")

--- a/tests/path_gateway_tar_test.go
+++ b/tests/path_gateway_tar_test.go
@@ -3,6 +3,7 @@ package tests
 import (
 	"testing"
 
+	"github.com/ipfs/gateway-conformance/tooling"
 	"github.com/ipfs/gateway-conformance/tooling/car"
 	. "github.com/ipfs/gateway-conformance/tooling/check"
 	"github.com/ipfs/gateway-conformance/tooling/specs"
@@ -11,6 +12,8 @@ import (
 )
 
 func TestTar(t *testing.T) {
+	tooling.LogTestGroup(t, GroupPathGateway)
+
 	fixtureOutside := car.MustOpenUnixfsCar("path_gateway_tar/outside-root.car")
 	fixtureInside := car.MustOpenUnixfsCar("path_gateway_tar/inside-root.car")
 

--- a/tests/path_gateway_tar_test.go
+++ b/tests/path_gateway_tar_test.go
@@ -76,6 +76,7 @@ func TestTar(t *testing.T) {
 		},
 		{
 			Name: "GET TAR with explicit ?filename= succeeds with modified Content-Disposition header",
+			Spec: "specs.ipfs.tech/http-gateways/path-gateway/#content-disposition-response-header",
 			Request: Request().
 				Path("/ipfs/{{cid}}", dirCID).
 				Query("filename", "testтест.tar").

--- a/tests/path_gateway_unixfs_test.go
+++ b/tests/path_gateway_unixfs_test.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/ipfs/gateway-conformance/tooling"
 	"github.com/ipfs/gateway-conformance/tooling/car"
 	. "github.com/ipfs/gateway-conformance/tooling/check"
 	"github.com/ipfs/gateway-conformance/tooling/ipns"
@@ -13,6 +14,8 @@ import (
 )
 
 func TestUnixFSDirectoryListing(t *testing.T) {
+	tooling.LogTestGroup(t, GroupPathGateway)
+
 	fixture := car.MustOpenUnixfsCar("dir_listing/fixtures.car")
 	root := fixture.MustGetNode()
 	file := fixture.MustGetNode("ą", "ę", "file-źł.txt")
@@ -76,6 +79,8 @@ func TestUnixFSDirectoryListing(t *testing.T) {
 }
 
 func TestGatewayCache(t *testing.T) {
+	tooling.LogTestGroup(t, GroupPathGateway)
+
 	fixture := car.MustOpenUnixfsCar("gateway-cache/fixtures.car")
 
 	tests := SugarTests{
@@ -308,6 +313,8 @@ func TestGatewayCache(t *testing.T) {
 }
 
 func TestGatewayCacheWithIPNS(t *testing.T) {
+	tooling.LogTestGroup(t, GroupPathGateway)
+
 	fixture := car.MustOpenUnixfsCar("gateway-cache/fixtures.car")
 	ipns := ipns.MustOpenIPNSRecordWithKey("gateway-cache/k51qzi5uqu5dlxdsdu5fpuu7h69wu4ohp32iwm9pdt9nq3y5rpn3ln9j12zfhe.ipns-record")
 	ipnsKey := ipns.Key()
@@ -404,6 +411,8 @@ func TestGatewayCacheWithIPNS(t *testing.T) {
 }
 
 func TestGatewaySymlink(t *testing.T) {
+	tooling.LogTestGroup(t, GroupPathGateway)
+
 	fixture := car.MustOpenUnixfsCar("path_gateway_unixfs/symlink.car")
 	rootDirCID := fixture.MustGetCid()
 
@@ -443,6 +452,8 @@ func TestGatewaySymlink(t *testing.T) {
 }
 
 func TestGatewayUnixFSFileRanges(t *testing.T) {
+	tooling.LogTestGroup(t, GroupPathGateway)
+
 	// Multi-range requests MUST conform to the HTTP semantics. The server does not
 	// need to be able to support returning multiple ranges. However, it must respond
 	// correctly.

--- a/tests/path_gateway_unixfs_test.go
+++ b/tests/path_gateway_unixfs_test.go
@@ -202,6 +202,7 @@ func TestGatewayCache(t *testing.T) {
 		// ==========
 		{
 			Name: "GET for /ipfs/ file with matching Etag in If-None-Match returns 304 Not Modified",
+			Spec: "specs.ipfs.tech/http-gateways/path-gateway/#if-none-match-request-header",
 			Request: Request().
 				Path("/ipfs/{{cid}}/root2/root3/root4/index.html", fixture.MustGetCid()).
 				Headers(
@@ -212,6 +213,7 @@ func TestGatewayCache(t *testing.T) {
 		},
 		{
 			Name: "GET for /ipfs/ dir with index.html file with matching Etag in If-None-Match returns 304 Not Modified",
+			Spec: "specs.ipfs.tech/http-gateways/path-gateway/#if-none-match-request-header",
 			Request: Request().
 				Path("/ipfs/{{cid}}/root2/root3/root4/", fixture.MustGetCid()).
 				Headers(
@@ -222,6 +224,7 @@ func TestGatewayCache(t *testing.T) {
 		},
 		{
 			Name: "GET for /ipfs/ file with matching third Etag in If-None-Match returns 304 Not Modified",
+			Spec: "specs.ipfs.tech/http-gateways/path-gateway/#if-none-match-request-header",
 			Request: Request().
 				Path("/ipfs/{{cid}}/root2/root3/root4/index.html", fixture.MustGetCid()).
 				Headers(
@@ -232,6 +235,7 @@ func TestGatewayCache(t *testing.T) {
 		},
 		{
 			Name: "GET for /ipfs/ file with matching weak Etag in If-None-Match returns 304 Not Modified",
+			Spec: "specs.ipfs.tech/http-gateways/path-gateway/#if-none-match-request-header",
 			Request: Request().
 				Path("/ipfs/{{cid}}/root2/root3/root4/index.html", fixture.MustGetCid()).
 				Headers(
@@ -242,6 +246,7 @@ func TestGatewayCache(t *testing.T) {
 		},
 		{
 			Name: "GET for /ipfs/ file with wildcard Etag in If-None-Match returns 304 Not Modified",
+			Spec: "specs.ipfs.tech/http-gateways/path-gateway/#if-none-match-request-header",
 			Request: Request().
 				Path("/ipfs/{{cid}}/root2/root3/root4/index.html", fixture.MustGetCid()).
 				Headers(
@@ -252,6 +257,7 @@ func TestGatewayCache(t *testing.T) {
 		},
 		{
 			Name: "GET for /ipfs/ dir listing with matching weak Etag in If-None-Match returns 304 Not Modified",
+			Spec: "specs.ipfs.tech/http-gateways/path-gateway/#if-none-match-request-header",
 			Request: Request().
 				Path("/ipfs/{{cid}}/root2/root3/", fixture.MustGetCid()).
 				Headers(

--- a/tests/path_gateway_unixfs_test.go
+++ b/tests/path_gateway_unixfs_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func TestUnixFSDirectoryListing(t *testing.T) {
-	tooling.LogTestGroup(t, GroupPathGateway)
+	tooling.LogTestGroup(t, GroupUnixFS)
 
 	fixture := car.MustOpenUnixfsCar("dir_listing/fixtures.car")
 	root := fixture.MustGetNode()
@@ -79,8 +79,6 @@ func TestUnixFSDirectoryListing(t *testing.T) {
 }
 
 func TestGatewayCache(t *testing.T) {
-	tooling.LogTestGroup(t, GroupPathGateway)
-
 	fixture := car.MustOpenUnixfsCar("gateway-cache/fixtures.car")
 
 	tests := SugarTests{
@@ -313,7 +311,7 @@ func TestGatewayCache(t *testing.T) {
 }
 
 func TestGatewayCacheWithIPNS(t *testing.T) {
-	tooling.LogTestGroup(t, GroupPathGateway)
+	tooling.LogTestGroup(t, GroupIPNS)
 
 	fixture := car.MustOpenUnixfsCar("gateway-cache/fixtures.car")
 	ipns := ipns.MustOpenIPNSRecordWithKey("gateway-cache/k51qzi5uqu5dlxdsdu5fpuu7h69wu4ohp32iwm9pdt9nq3y5rpn3ln9j12zfhe.ipns-record")
@@ -411,8 +409,6 @@ func TestGatewayCacheWithIPNS(t *testing.T) {
 }
 
 func TestGatewaySymlink(t *testing.T) {
-	tooling.LogTestGroup(t, GroupPathGateway)
-
 	fixture := car.MustOpenUnixfsCar("path_gateway_unixfs/symlink.car")
 	rootDirCID := fixture.MustGetCid()
 
@@ -452,7 +448,7 @@ func TestGatewaySymlink(t *testing.T) {
 }
 
 func TestGatewayUnixFSFileRanges(t *testing.T) {
-	tooling.LogTestGroup(t, GroupPathGateway)
+	tooling.LogTestGroup(t, GroupUnixFS)
 
 	// Multi-range requests MUST conform to the HTTP semantics. The server does not
 	// need to be able to support returning multiple ranges. However, it must respond

--- a/tests/redirects_file_test.go
+++ b/tests/redirects_file_test.go
@@ -15,6 +15,7 @@ import (
 )
 
 func TestRedirectsFileSupport(t *testing.T) {
+	tooling.LogSpecs(t, "specs.ipfs.tech/http-gateways/web-redirects-file/")
 	fixture := car.MustOpenUnixfsCar("redirects_file/redirects.car")
 	redirectDir := fixture.MustGetNode("examples")
 	redirectDirCID := redirectDir.Base32Cid()
@@ -165,7 +166,8 @@ func TestRedirectsFileSupport(t *testing.T) {
 							Contains("could not parse _redirects:"),
 							Contains(`forced redirects (or "shadowing") are not supported`),
 						),
-					),
+					).Spec("specs.ipfs.tech/http-gateways/web-redirects-file/#no-forced-redirects"),
+				Spec: "specs.ipfs.tech/http-gateways/web-redirects-file/#error-handling",
 			},
 			{
 				Name: "invalid file: request for $TOO_LARGE_REDIRECTS_DIR_HOSTNAME/not-found returns error about too large redirects file",
@@ -180,6 +182,7 @@ func TestRedirectsFileSupport(t *testing.T) {
 							Contains("redirects file size cannot exceed"),
 						),
 					),
+				Spec: "specs.ipfs.tech/http-gateways/web-redirects-file/#max-file-size",
 			},
 		}...)
 

--- a/tests/redirects_file_test.go
+++ b/tests/redirects_file_test.go
@@ -4,6 +4,7 @@ import (
 	"net/url"
 	"testing"
 
+	"github.com/ipfs/gateway-conformance/tooling"
 	"github.com/ipfs/gateway-conformance/tooling/car"
 	. "github.com/ipfs/gateway-conformance/tooling/check"
 	"github.com/ipfs/gateway-conformance/tooling/dnslink"
@@ -235,6 +236,7 @@ func TestRedirectsFileSupport(t *testing.T) {
 }
 
 func TestRedirectsFileSupportWithDNSLink(t *testing.T) {
+	tooling.LogTestGroup(t, GroupDNSLink)
 	dnsLinks := dnslink.MustOpenDNSLink("redirects_file/dnslink.yml")
 	dnsLink := dnsLinks.MustGet("custom-dnslink")
 

--- a/tests/subdomain_gateway_ipfs_test.go
+++ b/tests/subdomain_gateway_ipfs_test.go
@@ -4,6 +4,7 @@ import (
 	"net/url"
 	"testing"
 
+	"github.com/ipfs/gateway-conformance/tooling"
 	"github.com/ipfs/gateway-conformance/tooling/car"
 	. "github.com/ipfs/gateway-conformance/tooling/check"
 	"github.com/ipfs/gateway-conformance/tooling/helpers"
@@ -12,6 +13,8 @@ import (
 )
 
 func TestUnixFSDirectoryListingOnSubdomainGateway(t *testing.T) {
+	tooling.LogTestGroup(t, GroupSubdomainGateway)
+
 	fixture := car.MustOpenUnixfsCar("dir_listing/fixtures.car")
 	root := fixture.MustGetNode()
 	file := fixture.MustGetNode("ą", "ę", "file-źł.txt")
@@ -105,6 +108,8 @@ func TestUnixFSDirectoryListingOnSubdomainGateway(t *testing.T) {
 }
 
 func TestGatewaySubdomains(t *testing.T) {
+	tooling.LogTestGroup(t, GroupSubdomainGateway)
+
 	fixture := car.MustOpenUnixfsCar("subdomain_gateway/fixtures.car")
 
 	CIDVal := string(fixture.MustGetRawData("hello-CIDv1")) // hello

--- a/tests/subdomain_gateway_ipfs_test.go
+++ b/tests/subdomain_gateway_ipfs_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestUnixFSDirectoryListingOnSubdomainGateway(t *testing.T) {
-	tooling.LogTestGroup(t, GroupSubdomainGateway)
+	tooling.LogTestGroup(t, GroupUnixFS)
 
 	fixture := car.MustOpenUnixfsCar("dir_listing/fixtures.car")
 	root := fixture.MustGetNode()
@@ -108,7 +108,7 @@ func TestUnixFSDirectoryListingOnSubdomainGateway(t *testing.T) {
 }
 
 func TestGatewaySubdomains(t *testing.T) {
-	tooling.LogTestGroup(t, GroupSubdomainGateway)
+	tooling.LogTestGroup(t, GroupSubdomains)
 
 	fixture := car.MustOpenUnixfsCar("subdomain_gateway/fixtures.car")
 

--- a/tests/subdomain_gateway_ipns_test.go
+++ b/tests/subdomain_gateway_ipns_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 func TestGatewaySubdomainAndIPNS(t *testing.T) {
-	tooling.LogTestGroup(t, GroupSubdomainGateway)
+	tooling.LogTestGroup(t, GroupSubdomains)
 
 	tests := SugarTests{}
 
@@ -162,7 +162,7 @@ func TestGatewaySubdomainAndIPNS(t *testing.T) {
 }
 
 func TestSubdomainGatewayDNSLinkInlining(t *testing.T) {
-	tooling.LogTestGroup(t, GroupSubdomainGateway)
+	tooling.LogTestGroup(t, GroupSubdomains)
 
 	tests := SugarTests{}
 

--- a/tests/subdomain_gateway_ipns_test.go
+++ b/tests/subdomain_gateway_ipns_test.go
@@ -4,6 +4,7 @@ import (
 	"net/url"
 	"testing"
 
+	"github.com/ipfs/gateway-conformance/tooling"
 	"github.com/ipfs/gateway-conformance/tooling/car"
 	"github.com/ipfs/gateway-conformance/tooling/dnslink"
 	"github.com/ipfs/gateway-conformance/tooling/helpers"
@@ -15,6 +16,8 @@ import (
 )
 
 func TestGatewaySubdomainAndIPNS(t *testing.T) {
+	tooling.LogTestGroup(t, GroupSubdomainGateway)
+
 	tests := SugarTests{}
 
 	rsaFixture := ipns.MustOpenIPNSRecordWithKey("subdomain_gateway/QmVujd5Vb7moysJj8itnGufN7MEtPRCNHkKpNuA4onsRa3.ipns-record")
@@ -159,6 +162,8 @@ func TestGatewaySubdomainAndIPNS(t *testing.T) {
 }
 
 func TestSubdomainGatewayDNSLinkInlining(t *testing.T) {
+	tooling.LogTestGroup(t, GroupSubdomainGateway)
+
 	tests := SugarTests{}
 
 	// We're going to run the same test against multiple gateways (localhost, and a subdomain gateway)

--- a/tests/trustless_gateway_car_test.go
+++ b/tests/trustless_gateway_car_test.go
@@ -408,6 +408,7 @@ func TestTrustlessCarDagScopeAll(t *testing.T) {
 
 func TestTrustlessCarEntityBytes(t *testing.T) {
 	tooling.LogTestGroup(t, GroupBlockCar)
+	tooling.LogSpecs(t, "specs.ipfs.tech/http-gateways/trustless-gateway/#entity-bytes-request-query-parameter")
 
 	singleLayerHamtMultiBlockFilesFixture := car.MustOpenUnixfsCar("trustless_gateway_car/single-layer-hamt-with-multi-block-files.car")
 	subdirWithMixedBlockFiles := car.MustOpenUnixfsCar("trustless_gateway_car/subdir-with-mixed-block-files.car")

--- a/tests/trustless_gateway_car_test.go
+++ b/tests/trustless_gateway_car_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestTrustlessCarPathing(t *testing.T) {
-	tooling.LogTestGroup(t, GroupTrustlessGateway)
+	tooling.LogTestGroup(t, GroupBlockCar)
 
 	subdirTwoSingleBlockFilesFixture := car.MustOpenUnixfsCar("trustless_gateway_car/subdir-with-two-single-block-files.car")
 	singleLayerHamtMultiBlockFilesFixture := car.MustOpenUnixfsCar("trustless_gateway_car/single-layer-hamt-with-multi-block-files.car")
@@ -121,7 +121,7 @@ func TestTrustlessCarPathing(t *testing.T) {
 }
 
 func TestTrustlessCarDagScopeBlock(t *testing.T) {
-	tooling.LogTestGroup(t, GroupTrustlessGateway)
+	tooling.LogTestGroup(t, GroupBlockCar)
 
 	subdirTwoSingleBlockFilesFixture := car.MustOpenUnixfsCar("trustless_gateway_car/subdir-with-two-single-block-files.car")
 	singleLayerHamtMultiBlockFilesFixture := car.MustOpenUnixfsCar("trustless_gateway_car/single-layer-hamt-with-multi-block-files.car")
@@ -206,7 +206,7 @@ func TestTrustlessCarDagScopeBlock(t *testing.T) {
 }
 
 func TestTrustlessCarDagScopeEntity(t *testing.T) {
-	tooling.LogTestGroup(t, GroupTrustlessGateway)
+	tooling.LogTestGroup(t, GroupBlockCar)
 
 	subdirTwoSingleBlockFilesFixture := car.MustOpenUnixfsCar("trustless_gateway_car/subdir-with-two-single-block-files.car")
 	singleLayerHamtMultiBlockFilesFixture := car.MustOpenUnixfsCar("trustless_gateway_car/single-layer-hamt-with-multi-block-files.car")
@@ -342,7 +342,7 @@ func TestTrustlessCarDagScopeEntity(t *testing.T) {
 }
 
 func TestTrustlessCarDagScopeAll(t *testing.T) {
-	tooling.LogTestGroup(t, GroupTrustlessGateway)
+	tooling.LogTestGroup(t, GroupBlockCar)
 
 	subdirWithMixedBlockFiles := car.MustOpenUnixfsCar("trustless_gateway_car/subdir-with-mixed-block-files.car")
 
@@ -407,7 +407,7 @@ func TestTrustlessCarDagScopeAll(t *testing.T) {
 }
 
 func TestTrustlessCarEntityBytes(t *testing.T) {
-	tooling.LogTestGroup(t, GroupTrustlessGateway)
+	tooling.LogTestGroup(t, GroupBlockCar)
 
 	singleLayerHamtMultiBlockFilesFixture := car.MustOpenUnixfsCar("trustless_gateway_car/single-layer-hamt-with-multi-block-files.car")
 	subdirWithMixedBlockFiles := car.MustOpenUnixfsCar("trustless_gateway_car/subdir-with-mixed-block-files.car")
@@ -669,7 +669,7 @@ func TestTrustlessCarEntityBytes(t *testing.T) {
 }
 
 func TestTrustlessCarOrderAndDuplicates(t *testing.T) {
-	tooling.LogTestGroup(t, GroupTrustlessGateway)
+	tooling.LogTestGroup(t, GroupBlockCar)
 
 	dirWithDuplicateFiles := car.MustOpenUnixfsCar("trustless_gateway_car/dir-with-duplicate-files.car")
 	// This array is defined at the SPEC level and should not depend on library behavior

--- a/tests/trustless_gateway_car_test.go
+++ b/tests/trustless_gateway_car_test.go
@@ -3,6 +3,7 @@ package tests
 import (
 	"testing"
 
+	"github.com/ipfs/gateway-conformance/tooling"
 	"github.com/ipfs/gateway-conformance/tooling/car"
 	. "github.com/ipfs/gateway-conformance/tooling/check"
 	"github.com/ipfs/gateway-conformance/tooling/helpers"
@@ -11,6 +12,8 @@ import (
 )
 
 func TestTrustlessCarPathing(t *testing.T) {
+	tooling.LogTestGroup(t, GroupTrustlessGateway)
+
 	subdirTwoSingleBlockFilesFixture := car.MustOpenUnixfsCar("trustless_gateway_car/subdir-with-two-single-block-files.car")
 	singleLayerHamtMultiBlockFilesFixture := car.MustOpenUnixfsCar("trustless_gateway_car/single-layer-hamt-with-multi-block-files.car")
 	dirWithDagCborWithLinksFixture := car.MustOpenUnixfsCar("trustless_gateway_car/dir-with-dag-cbor-with-links.car")
@@ -118,6 +121,8 @@ func TestTrustlessCarPathing(t *testing.T) {
 }
 
 func TestTrustlessCarDagScopeBlock(t *testing.T) {
+	tooling.LogTestGroup(t, GroupTrustlessGateway)
+
 	subdirTwoSingleBlockFilesFixture := car.MustOpenUnixfsCar("trustless_gateway_car/subdir-with-two-single-block-files.car")
 	singleLayerHamtMultiBlockFilesFixture := car.MustOpenUnixfsCar("trustless_gateway_car/single-layer-hamt-with-multi-block-files.car")
 
@@ -201,6 +206,8 @@ func TestTrustlessCarDagScopeBlock(t *testing.T) {
 }
 
 func TestTrustlessCarDagScopeEntity(t *testing.T) {
+	tooling.LogTestGroup(t, GroupTrustlessGateway)
+
 	subdirTwoSingleBlockFilesFixture := car.MustOpenUnixfsCar("trustless_gateway_car/subdir-with-two-single-block-files.car")
 	singleLayerHamtMultiBlockFilesFixture := car.MustOpenUnixfsCar("trustless_gateway_car/single-layer-hamt-with-multi-block-files.car")
 	subdirWithMixedBlockFiles := car.MustOpenUnixfsCar("trustless_gateway_car/subdir-with-mixed-block-files.car")
@@ -335,6 +342,8 @@ func TestTrustlessCarDagScopeEntity(t *testing.T) {
 }
 
 func TestTrustlessCarDagScopeAll(t *testing.T) {
+	tooling.LogTestGroup(t, GroupTrustlessGateway)
+
 	subdirWithMixedBlockFiles := car.MustOpenUnixfsCar("trustless_gateway_car/subdir-with-mixed-block-files.car")
 
 	tests := SugarTests{
@@ -398,6 +407,8 @@ func TestTrustlessCarDagScopeAll(t *testing.T) {
 }
 
 func TestTrustlessCarEntityBytes(t *testing.T) {
+	tooling.LogTestGroup(t, GroupTrustlessGateway)
+
 	singleLayerHamtMultiBlockFilesFixture := car.MustOpenUnixfsCar("trustless_gateway_car/single-layer-hamt-with-multi-block-files.car")
 	subdirWithMixedBlockFiles := car.MustOpenUnixfsCar("trustless_gateway_car/subdir-with-mixed-block-files.car")
 	missingBlockFixture := car.MustOpenUnixfsCar("trustless_gateway_car/file-3k-and-3-blocks-missing-block.car")
@@ -658,6 +669,8 @@ func TestTrustlessCarEntityBytes(t *testing.T) {
 }
 
 func TestTrustlessCarOrderAndDuplicates(t *testing.T) {
+	tooling.LogTestGroup(t, GroupTrustlessGateway)
+
 	dirWithDuplicateFiles := car.MustOpenUnixfsCar("trustless_gateway_car/dir-with-duplicate-files.car")
 	// This array is defined at the SPEC level and should not depend on library behavior
 	// See the recipe for `dir-with-duplicate-files.car`

--- a/tests/trustless_gateway_ipns_test.go
+++ b/tests/trustless_gateway_ipns_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestGatewayIPNSRecord(t *testing.T) {
-	tooling.LogTestGroup(t, GroupTrustlessGateway)
+	tooling.LogTestGroup(t, GroupIPNS)
 
 	fixture := car.MustOpenUnixfsCar("ipns_records/fixtures.car")
 	file := fixture.MustGetRoot()

--- a/tests/trustless_gateway_ipns_test.go
+++ b/tests/trustless_gateway_ipns_test.go
@@ -3,6 +3,7 @@ package tests
 import (
 	"testing"
 
+	"github.com/ipfs/gateway-conformance/tooling"
 	"github.com/ipfs/gateway-conformance/tooling/car"
 	. "github.com/ipfs/gateway-conformance/tooling/ipns"
 	"github.com/ipfs/gateway-conformance/tooling/specs"
@@ -10,6 +11,8 @@ import (
 )
 
 func TestGatewayIPNSRecord(t *testing.T) {
+	tooling.LogTestGroup(t, GroupTrustlessGateway)
+
 	fixture := car.MustOpenUnixfsCar("ipns_records/fixtures.car")
 	file := fixture.MustGetRoot()
 	fileCID := file.Cid()

--- a/tests/trustless_gateway_raw_test.go
+++ b/tests/trustless_gateway_raw_test.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/ipfs/gateway-conformance/tooling"
 	"github.com/ipfs/gateway-conformance/tooling/car"
 	. "github.com/ipfs/gateway-conformance/tooling/check"
 	"github.com/ipfs/gateway-conformance/tooling/specs"
@@ -12,6 +13,8 @@ import (
 )
 
 func TestTrustlessRaw(t *testing.T) {
+	tooling.LogTestGroup(t, GroupTrustlessGateway)
+
 	fixture := car.MustOpenUnixfsCar("gateway-raw-block.car")
 
 	tests := SugarTests{
@@ -128,6 +131,8 @@ func TestTrustlessRaw(t *testing.T) {
 }
 
 func TestTrustlessRawRanges(t *testing.T) {
+	tooling.LogTestGroup(t, GroupTrustlessGateway)
+
 	// Multi-range requests MUST conform to the HTTP semantics. The server does not
 	// need to be able to support returning multiple ranges. However, it must respond
 	// correctly.

--- a/tests/trustless_gateway_raw_test.go
+++ b/tests/trustless_gateway_raw_test.go
@@ -14,7 +14,8 @@ import (
 
 func TestTrustlessRaw(t *testing.T) {
 	tooling.LogTestGroup(t, GroupBlockCar)
-
+	tooling.LogSpecs(t, "specs.ipfs.tech/http-gateways/trustless-gateway/#block-responses-application-vnd-ipld-raw")
+	
 	fixture := car.MustOpenUnixfsCar("gateway-raw-block.car")
 
 	tests := SugarTests{
@@ -132,6 +133,7 @@ func TestTrustlessRaw(t *testing.T) {
 
 func TestTrustlessRawRanges(t *testing.T) {
 	tooling.LogTestGroup(t, GroupBlockCar)
+	// @lidel: "The optional entity-bytes=from:to parameter is available only for CAR requests."
 
 	// Multi-range requests MUST conform to the HTTP semantics. The server does not
 	// need to be able to support returning multiple ranges. However, it must respond
@@ -145,7 +147,7 @@ func TestTrustlessRawRanges(t *testing.T) {
 
 	RunWithSpecs(t, SugarTests{
 		{
-			Name: "GETaa with application/vnd.ipld.raw with single range request includes correct bytes",
+			Name: "GET with application/vnd.ipld.raw with single range request includes correct bytes",
 			Request: Request().
 				Path("/ipfs/{{cid}}", fixture.MustGetCid("dir", "ascii.txt")).
 				Headers(

--- a/tests/trustless_gateway_raw_test.go
+++ b/tests/trustless_gateway_raw_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestTrustlessRaw(t *testing.T) {
-	tooling.LogTestGroup(t, GroupTrustlessGateway)
+	tooling.LogTestGroup(t, GroupBlockCar)
 
 	fixture := car.MustOpenUnixfsCar("gateway-raw-block.car")
 
@@ -131,7 +131,7 @@ func TestTrustlessRaw(t *testing.T) {
 }
 
 func TestTrustlessRawRanges(t *testing.T) {
-	tooling.LogTestGroup(t, GroupTrustlessGateway)
+	tooling.LogTestGroup(t, GroupBlockCar)
 
 	// Multi-range requests MUST conform to the HTTP semantics. The server does not
 	// need to be able to support returning multiple ranges. However, it must respond

--- a/tests/trustless_gateway_raw_test.go
+++ b/tests/trustless_gateway_raw_test.go
@@ -15,7 +15,7 @@ import (
 func TestTrustlessRaw(t *testing.T) {
 	tooling.LogTestGroup(t, GroupBlockCar)
 	tooling.LogSpecs(t, "specs.ipfs.tech/http-gateways/trustless-gateway/#block-responses-application-vnd-ipld-raw")
-	
+
 	fixture := car.MustOpenUnixfsCar("gateway-raw-block.car")
 
 	tests := SugarTests{

--- a/tooling/metadata.go
+++ b/tooling/metadata.go
@@ -3,8 +3,6 @@ package tooling
 import (
 	"encoding/json"
 	"testing"
-
-	"github.com/ipfs/gateway-conformance/tooling/test"
 )
 
 func LogMetadata(t *testing.T, value interface{}) {
@@ -44,12 +42,14 @@ func LogJobURL(t *testing.T) {
 	})
 }
 
-func LogGatewayURL(t *testing.T) {
+func LogSpecs(t *testing.T, specs ...string) {
+	if len(specs) == 0 {
+		return
+	}
+
 	LogMetadata(t, struct {
-		GatewayURL          string `json:"gateway_url"`
-		SubdomainGatewayURL string `json:"subdomain_gateway_url"`
+		Specs []string `json:"specs"`
 	}{
-		GatewayURL:          test.GatewayURL,
-		SubdomainGatewayURL: test.SubdomainGatewayURL,
+		Specs: specs,
 	})
 }

--- a/tooling/metadata.go
+++ b/tooling/metadata.go
@@ -18,6 +18,16 @@ func LogMetadata(t *testing.T, value interface{}) {
 	t.Logf("--- META: %s", string(jsonValue))
 }
 
+func LogTestGroup(t *testing.T, name string) {
+	t.Helper()
+
+	LogMetadata(t, struct {
+		Group string `json:"group"`
+	}{
+		Group: name,
+	})
+}
+
 func LogVersion(t *testing.T) {
 	LogMetadata(t, struct {
 		Version string `json:"version"`

--- a/tooling/test/sugar.go
+++ b/tooling/test/sugar.go
@@ -137,6 +137,7 @@ type ExpectBuilder struct {
 	StatusCode_ int             `json:"statusCode,omitempty"`
 	Headers_    []HeaderBuilder `json:"headers,omitempty"`
 	Body_       interface{}     `json:"body,omitempty"`
+	Specs_      []string        `json:"specs,omitempty"`
 }
 
 func Expect() ExpectBuilder {
@@ -154,6 +155,16 @@ func (e ExpectBuilder) Status(statusCode int) ExpectBuilder {
 
 func (e ExpectBuilder) Header(h HeaderBuilder) ExpectBuilder {
 	e.Headers_ = append(e.Headers_, h)
+	return e
+}
+
+func (e ExpectBuilder) Spec(spec string) ExpectBuilder {
+	e.Specs_ = []string{spec}
+	return e
+}
+
+func (e ExpectBuilder) Specs(specs ...string) ExpectBuilder {
+	e.Specs_ = specs
 	return e
 }
 
@@ -213,6 +224,7 @@ type HeaderBuilder struct {
 	Value_ string                `json:"value,omitempty"`
 	Check_ check.Check[[]string] `json:"check,omitempty"`
 	Hint_  string                `json:"hint,omitempty"`
+	Specs_ []string              `json:"specs,omitempty"`
 	Not_   bool                  `json:"not,omitempty"`
 }
 
@@ -242,6 +254,16 @@ func (h HeaderBuilder) Matches(value string, rest ...any) HeaderBuilder {
 
 func (h HeaderBuilder) Hint(hint string) HeaderBuilder {
 	h.Hint_ = hint
+	return h
+}
+
+func (h HeaderBuilder) Specs(specs ...string) HeaderBuilder {
+	h.Specs_ = specs
+	return h
+}
+
+func (h HeaderBuilder) Spec(spec string) HeaderBuilder {
+	h.Specs_ = []string{spec}
 	return h
 }
 

--- a/tooling/test/test.go
+++ b/tooling/test/test.go
@@ -6,12 +6,15 @@ import (
 	"testing"
 	"time"
 
+	"github.com/ipfs/gateway-conformance/tooling"
 	"github.com/ipfs/gateway-conformance/tooling/specs"
 )
 
 type SugarTest struct {
 	Name      string
 	Hint      string
+	Spec      string
+	Specs     []string
 	Request   RequestBuilder
 	Requests  []RequestBuilder
 	Response  ExpectBuilder
@@ -19,6 +22,22 @@ type SugarTest struct {
 }
 
 type SugarTests []SugarTest
+
+func (s *SugarTest) AllSpecs() []string {
+	if len(s.Specs) > 0 && s.Spec != "" {
+		panic("cannot have both Spec and Specs")
+	}
+
+	if len(s.Specs) > 0 {
+		return s.Specs
+	}
+
+	if s.Spec != "" {
+		return []string{s.Spec}
+	}
+
+	return []string{}
+}
 
 func RunWithSpecs(
 	t *testing.T,
@@ -51,6 +70,7 @@ func run(t *testing.T, tests SugarTests) {
 
 		if len(test.Requests) > 0 {
 			t.Run(test.Name, func(t *testing.T) {
+				tooling.LogSpecs(t, test.AllSpecs()...)
 				responses := make([]*http.Response, 0, len(test.Requests))
 
 				for _, req := range test.Requests {
@@ -63,6 +83,7 @@ func run(t *testing.T, tests SugarTests) {
 			})
 		} else {
 			t.Run(test.Name, func(t *testing.T) {
+				tooling.LogSpecs(t, test.AllSpecs()...)
 				_, res, localReport := runRequest(timeout, t, test, test.Request)
 				validateResponse(t, test.Response, res, localReport)
 			})

--- a/tooling/test/validate.go
+++ b/tooling/test/validate.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/ipfs/gateway-conformance/tooling"
 	"github.com/ipfs/gateway-conformance/tooling/check"
 )
 
@@ -16,15 +17,19 @@ func validateResponse(
 	localReport Reporter,
 ) {
 	t.Helper()
+	tooling.LogSpecs(t, expected.Specs_...)
 
 	if expected.StatusCode_ != 0 {
-		if res.StatusCode != expected.StatusCode_ {
-			localReport(t, "Status code is not %d. It is %d", expected.StatusCode_, res.StatusCode)
-		}
+		t.Run("Status code", func(t *testing.T) {
+			if res.StatusCode != expected.StatusCode_ {
+				localReport(t, "Status code is not %d. It is %d", expected.StatusCode_, res.StatusCode)
+			}
+		})
 	}
 
 	for _, header := range expected.Headers_ {
 		t.Run(fmt.Sprintf("Header %s", header.Key_), func(t *testing.T) {
+			tooling.LogSpecs(t, header.Specs_...)
 			actual := res.Header.Values(header.Key_)
 
 			c := header.Check_


### PR DESCRIPTION
Contributes to #123 

Add a "User Taxonomy" different from the specs. This will be used in gateway checker and other user-facing tooling.

- [x] Introduce API
- [x] Add "most" tests to groups

Add specs that connect with specs.ipfs.tech

- [x] add spec(s)
- [x] update (some) tests with these
- [x] use these in the outputs (at least in markdown file)

⚠️ I'm not trying to assign specs and groups to all the tests for now, just demonstrate the specs API. We'll build the rest of the dashboard, maybe even a spec coverage table first.
 
Follow-ups:

- [ ] use these in dashboard generation
- [ ] validate these at build time by checking the pages & anchor exists