### PR TITLE
feat: range request helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+- Added tests for HTTP Range requests, as well as some basic helpers for `AnyOf` and `AllOf`. [PR](https://github.com/ipfs/gateway-conformance/pull/162)
 ## [0.3.1] - 2023-09-15
 ### Added
 - Specs Dashboard Output. [PR](https://github.com/ipfs/gateway-conformance/pull/163)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
-
 ### Added
-
 - Added tests for HTTP Range requests, as well as some basic helpers for `AnyOf` and `AllOf`. [PR](https://github.com/ipfs/gateway-conformance/pull/162)
+
 ## [0.3.1] - 2023-09-15
 ### Added
 - Specs Dashboard Output. [PR](https://github.com/ipfs/gateway-conformance/pull/163)

--- a/tests/path_gateway_dag_test.go
+++ b/tests/path_gateway_dag_test.go
@@ -234,25 +234,25 @@ func TestPlainCodec(t *testing.T) {
 
 		var dagFormattedResponse []byte
 
-		tests := &SugarTests{}
-		tests.Append(
-			helpers.IncludeRandomRangeTests(t,
-				SugarTest{
-					Name: Fmt(`GET {{name}} without Accept or format= has expected "{{format}}" Content-Type and body as-is`, row.Name, row.Format),
-					Hint: `
+		tests := SugarTests{}.
+			Append(
+				helpers.IncludeRandomRangeTests(t,
+					SugarTest{
+						Name: Fmt(`GET {{name}} without Accept or format= has expected "{{format}}" Content-Type and body as-is`, row.Name, row.Format),
+						Hint: `
 				No explicit format, just codec in CID
 				`,
-					Request: Request().
-						Path("/ipfs/{{cid}}", plainCID),
-					Response: Expect().
-						Headers(
-							Header("Content-Disposition").
-								Contains(Fmt(`{{disposition}}; filename="{{cid}}.{{format}}"`, row.Disposition, plainCID, row.Format)),
-						),
-				},
-				plain.RawData(),
-				Fmt("application/{{format}}", row.Format),
-			)...).
+						Request: Request().
+							Path("/ipfs/{{cid}}", plainCID),
+						Response: Expect().
+							Headers(
+								Header("Content-Disposition").
+									Contains(Fmt(`{{disposition}}; filename="{{cid}}.{{format}}"`, row.Disposition, plainCID, row.Format)),
+							),
+					},
+					plain.RawData(),
+					Fmt("application/{{format}}", row.Format),
+				)...).
 			Append(
 				helpers.IncludeRandomRangeTests(t,
 					SugarTest{
@@ -323,7 +323,7 @@ func TestPlainCodec(t *testing.T) {
 				},
 			)
 
-		RunWithSpecs(t, *tests, specs.PathGatewayDAG)
+		RunWithSpecs(t, tests, specs.PathGatewayDAG)
 
 		if dagFormattedResponse != nil {
 			rangeTests := helpers.OnlyRandomRangeTests(t,

--- a/tests/path_gateway_dag_test.go
+++ b/tests/path_gateway_dag_test.go
@@ -253,8 +253,8 @@ func TestPlainCodec(t *testing.T) {
 						),
 				},
 				helpers.ByteRanges{
-					helpers.SimpleByteRange(0, 5, plain.RawData()[0:6]),
-					helpers.SimpleByteRange(10, 15, plain.RawData()[10:16]),
+					helpers.SimpleByteRange(0, 5),
+					helpers.SimpleByteRange(10, 15),
 				},
 				plain.RawData(),
 			)...).
@@ -277,8 +277,8 @@ func TestPlainCodec(t *testing.T) {
 							),
 					},
 					helpers.ByteRanges{
-						helpers.SimpleByteRange(0, 5, plain.RawData()[0:6]),
-						helpers.SimpleByteRange(10, 15, plain.RawData()[10:16]),
+						helpers.SimpleByteRange(0, 5),
+						helpers.SimpleByteRange(10, 15),
 					},
 					plain.RawData(),
 				)...).
@@ -303,8 +303,8 @@ func TestPlainCodec(t *testing.T) {
 							),
 					},
 					helpers.ByteRanges{
-						helpers.SimpleByteRange(0, 5, plain.RawData()[0:6]),
-						helpers.SimpleByteRange(10, 15, plain.RawData()[10:16]),
+						helpers.SimpleByteRange(0, 5),
+						helpers.SimpleByteRange(10, 15),
 					},
 					plain.RawData(),
 				)...).
@@ -360,8 +360,8 @@ func TestPlainCodec(t *testing.T) {
 						),
 				},
 				helpers.ByteRanges{
-					helpers.SimpleByteRange(0, 5, dagFormattedResponse[0:6]),
-					helpers.SimpleByteRange(10, 15, dagFormattedResponse[10:16]),
+					helpers.SimpleByteRange(0, 5),
+					helpers.SimpleByteRange(10, 15),
 				},
 				dagFormattedResponse,
 			)
@@ -644,8 +644,8 @@ func TestNativeDag(t *testing.T) {
 					),
 			},
 			helpers.ByteRanges{
-				helpers.SimpleByteRange(6, 16, dagTraversal.RawData()[6:17]),
-				helpers.SimpleByteRange(20, 25, dagTraversal.RawData()[20:26]),
+				helpers.SimpleByteRange(6, 16),
+				helpers.SimpleByteRange(20, 25),
 			},
 			dagTraversal.RawData(),
 		)...).Append(
@@ -663,8 +663,8 @@ func TestNativeDag(t *testing.T) {
 						),
 				},
 				helpers.ByteRanges{
-					helpers.SimpleByteRange(6, 16, dagTraversal.RawData()[6:17]),
-					helpers.SimpleByteRange(20, 25, dagTraversal.RawData()[20:26]),
+					helpers.SimpleByteRange(6, 16),
+					helpers.SimpleByteRange(20, 25),
 				}, dagTraversal.RawData(),
 			)...).Append(
 			helpers.RangeTestTransform(t,
@@ -681,8 +681,8 @@ func TestNativeDag(t *testing.T) {
 						),
 				},
 				helpers.ByteRanges{
-					helpers.SimpleByteRange(6, 16, dagTraversal.RawData()[6:17]),
-					helpers.SimpleByteRange(20, 25, dagTraversal.RawData()[20:26]),
+					helpers.SimpleByteRange(6, 16),
+					helpers.SimpleByteRange(20, 25),
 				},
 				dagTraversal.RawData(),
 			)...)
@@ -727,8 +727,8 @@ func TestNativeDag(t *testing.T) {
 				Response: Expect(),
 			},
 			helpers.ByteRanges{
-				helpers.SimpleByteRange(1, 5, dagJsonConvertedData[1:6]),
-				helpers.SimpleByteRange(93, 104, dagJsonConvertedData[93:105])},
+				helpers.SimpleByteRange(1, 5),
+				helpers.SimpleByteRange(93, 104)},
 			dagJsonConvertedData)
 
 		RunWithSpecs(t, rangeTests, specs.PathGatewayDAG)
@@ -767,8 +767,8 @@ func TestNativeDag(t *testing.T) {
 					),
 				Response: Expect(),
 			}, helpers.ByteRanges{
-				helpers.SimpleByteRange(1, 5, dagCborHTMLRendering[1:6]),
-				helpers.SimpleByteRange(93, 104, dagCborHTMLRendering[93:105])},
+				helpers.SimpleByteRange(1, 5),
+				helpers.SimpleByteRange(93, 104)},
 			dagCborHTMLRendering)
 
 		RunWithSpecs(t, rangeTests, specs.PathGatewayDAG)

--- a/tests/path_gateway_dag_test.go
+++ b/tests/path_gateway_dag_test.go
@@ -236,7 +236,7 @@ func TestPlainCodec(t *testing.T) {
 
 		tests := &SugarTests{}
 		tests.Append(
-			helpers.IncludeRangeTests(t,
+			helpers.IncludeRandomRangeTests(t,
 				SugarTest{
 					Name: Fmt(`GET {{name}} without Accept or format= has expected "{{format}}" Content-Type and body as-is`, row.Name, row.Format),
 					Hint: `
@@ -250,12 +250,11 @@ func TestPlainCodec(t *testing.T) {
 								Contains(Fmt(`{{disposition}}; filename="{{cid}}.{{format}}"`, row.Disposition, plainCID, row.Format)),
 						),
 				},
-				nil,
 				plain.RawData(),
 				Fmt("application/{{format}}", row.Format),
 			)...).
 			Append(
-				helpers.IncludeRangeTests(t,
+				helpers.IncludeRandomRangeTests(t,
 					SugarTest{
 						Name: Fmt("GET {{name}} with ?format= has expected {{format}} Content-Type and body as-is", row.Name, row.Format),
 						Hint: `
@@ -270,12 +269,11 @@ func TestPlainCodec(t *testing.T) {
 									Contains(`{{disposition}}; filename="{{cid}}.{{format}}"`, row.Disposition, plainCID, row.Format),
 							),
 					},
-					nil,
 					plain.RawData(),
 					Fmt("application/{{format}}", row.Format),
 				)...).
 			Append(
-				helpers.IncludeRangeTests(t,
+				helpers.IncludeRandomRangeTests(t,
 					SugarTest{
 						Name: Fmt("GET {{name}} with Accept has expected {{format}} Content-Type and body as-is, with single range request", row.Name, row.Format),
 						Hint: `
@@ -292,7 +290,6 @@ func TestPlainCodec(t *testing.T) {
 									Contains(`{{disposition}}; filename="{{cid}}.{{format}}"`, row.Disposition, plainCID, row.Format),
 							),
 					},
-					nil,
 					plain.RawData(),
 					Fmt("application/{{format}}", row.Format),
 				)...).
@@ -329,7 +326,7 @@ func TestPlainCodec(t *testing.T) {
 		RunWithSpecs(t, *tests, specs.PathGatewayDAG)
 
 		if dagFormattedResponse != nil {
-			rangeTests := helpers.RangeTestTransform(t,
+			rangeTests := helpers.OnlyRandomRangeTests(t,
 				SugarTest{
 					Name: Fmt("GET {{name}} with format=dag-{{format}} interprets {{format}} as dag-* variant and produces expected Content-Type and body, with single range request", row.Name, row.Format),
 					Hint: `
@@ -345,7 +342,6 @@ func TestPlainCodec(t *testing.T) {
 								Contains(`{{disposition}}; filename="{{cid}}.{{format}}"`, row.Disposition, plainOrDagCID, row.Format),
 						),
 				},
-				nil,
 				dagFormattedResponse,
 				Fmt("application/vnd.ipld.dag-{{format}}", row.Format),
 			)
@@ -617,16 +613,16 @@ func TestNativeDag(t *testing.T) {
 				),
 			},
 		}
-		tests.Append(helpers.RangeTestTransform(t,
+		tests.Append(helpers.OnlyRandomRangeTests(t,
 			SugarTest{
 				Name: Fmt("GET {{name}} on /ipfs with no explicit header", row.Name),
 				Request: Request().
 					Path("/ipfs/{{cid}}/", dagTraversalCID),
 				Response: Expect(),
-			}, nil,
+			},
 			dagTraversal.RawData(), Fmt("application/vnd.ipld.dag-{{format}}", row.Format),
 		)...).Append(
-			helpers.RangeTestTransform(t,
+			helpers.OnlyRandomRangeTests(t,
 				SugarTest{
 					Name: Fmt("GET {{name}} on /ipfs with dag content headers", row.Name),
 					Request: Request().
@@ -636,10 +632,10 @@ func TestNativeDag(t *testing.T) {
 						),
 					Response: Expect(),
 				},
-				nil, dagTraversal.RawData(),
+				dagTraversal.RawData(),
 				Fmt("application/vnd.ipld.dag-{{format}}", row.Format),
 			)...).Append(
-			helpers.RangeTestTransform(t,
+			helpers.OnlyRandomRangeTests(t,
 				SugarTest{
 					Name: Fmt("GET {{name}} on /ipfs with non-dag content headers", row.Name),
 					Request: Request().
@@ -649,7 +645,6 @@ func TestNativeDag(t *testing.T) {
 						),
 					Response: Expect(),
 				},
-				nil,
 				dagTraversal.RawData(),
 				Fmt("application/{{format}}", row.Format),
 			)...)
@@ -681,7 +676,7 @@ func TestNativeDag(t *testing.T) {
 	}, specs.PathGatewayDAG)
 
 	if dagJsonConvertedData != nil {
-		rangeTests := helpers.RangeTestTransform(
+		rangeTests := helpers.OnlyRandomRangeTests(
 			t,
 			SugarTest{
 				Name: "Convert application/vnd.ipld.dag-cbor to application/vnd.ipld.dag-json with range request includes correct bytes",
@@ -693,7 +688,6 @@ func TestNativeDag(t *testing.T) {
 					),
 				Response: Expect(),
 			},
-			nil,
 			dagJsonConvertedData,
 			"application/vnd.ipld.dag-json")
 
@@ -722,7 +716,7 @@ func TestNativeDag(t *testing.T) {
 	}, specs.PathGatewayDAG)
 
 	if dagCborHTMLRendering != nil {
-		rangeTests := helpers.RangeTestTransform(t,
+		rangeTests := helpers.OnlyRandomRangeTests(t,
 			SugarTest{
 				Name: "Convert application/vnd.ipld.dag-cbor to text/html with range request includes correct bytes",
 				Hint: "",
@@ -732,7 +726,7 @@ func TestNativeDag(t *testing.T) {
 						Header("Accept", "text/html"),
 					),
 				Response: Expect(),
-			}, nil,
+			},
 			dagCborHTMLRendering,
 			"text/html")
 

--- a/tests/path_gateway_dag_test.go
+++ b/tests/path_gateway_dag_test.go
@@ -252,10 +252,7 @@ func TestPlainCodec(t *testing.T) {
 								Contains(Fmt("application/{{format}}", row.Format)),
 						),
 				},
-				helpers.ByteRanges{
-					helpers.SimpleByteRange(0, 5),
-					helpers.SimpleByteRange(10, 15),
-				},
+				nil,
 				plain.RawData(),
 			)...).
 			Append(
@@ -276,10 +273,7 @@ func TestPlainCodec(t *testing.T) {
 									Contains("application/{{format}}", row.Format),
 							),
 					},
-					helpers.ByteRanges{
-						helpers.SimpleByteRange(0, 5),
-						helpers.SimpleByteRange(10, 15),
-					},
+					nil,
 					plain.RawData(),
 				)...).
 			Append(
@@ -302,10 +296,7 @@ func TestPlainCodec(t *testing.T) {
 									Contains("application/{{format}}", row.Format),
 							),
 					},
-					helpers.ByteRanges{
-						helpers.SimpleByteRange(0, 5),
-						helpers.SimpleByteRange(10, 15),
-					},
+					nil,
 					plain.RawData(),
 				)...).
 			Append(
@@ -359,10 +350,7 @@ func TestPlainCodec(t *testing.T) {
 								Contains("application/vnd.ipld.dag-{{format}}", row.Format),
 						),
 				},
-				helpers.ByteRanges{
-					helpers.SimpleByteRange(0, 5),
-					helpers.SimpleByteRange(10, 15),
-				},
+				nil,
 				dagFormattedResponse,
 			)
 			RunWithSpecs(t, rangeTests, specs.PathGatewayDAG)
@@ -642,11 +630,7 @@ func TestNativeDag(t *testing.T) {
 					Headers(
 						Header("Content-Type", "application/vnd.ipld.dag-{{format}}", row.Format),
 					),
-			},
-			helpers.ByteRanges{
-				helpers.SimpleByteRange(6, 16),
-				helpers.SimpleByteRange(20, 25),
-			},
+			}, nil,
 			dagTraversal.RawData(),
 		)...).Append(
 			helpers.RangeTestTransform(t,
@@ -662,10 +646,7 @@ func TestNativeDag(t *testing.T) {
 							Header("Content-Type", "application/vnd.ipld.dag-{{format}}", row.Format),
 						),
 				},
-				helpers.ByteRanges{
-					helpers.SimpleByteRange(6, 16),
-					helpers.SimpleByteRange(20, 25),
-				}, dagTraversal.RawData(),
+				nil, dagTraversal.RawData(),
 			)...).Append(
 			helpers.RangeTestTransform(t,
 				SugarTest{
@@ -680,10 +661,7 @@ func TestNativeDag(t *testing.T) {
 							Header("Content-Type", "application/{{format}}", row.Format),
 						),
 				},
-				helpers.ByteRanges{
-					helpers.SimpleByteRange(6, 16),
-					helpers.SimpleByteRange(20, 25),
-				},
+				nil,
 				dagTraversal.RawData(),
 			)...)
 
@@ -726,9 +704,7 @@ func TestNativeDag(t *testing.T) {
 					),
 				Response: Expect(),
 			},
-			helpers.ByteRanges{
-				helpers.SimpleByteRange(1, 5),
-				helpers.SimpleByteRange(93, 104)},
+			nil,
 			dagJsonConvertedData)
 
 		RunWithSpecs(t, rangeTests, specs.PathGatewayDAG)
@@ -766,9 +742,7 @@ func TestNativeDag(t *testing.T) {
 						Header("Accept", "text/html"),
 					),
 				Response: Expect(),
-			}, helpers.ByteRanges{
-				helpers.SimpleByteRange(1, 5),
-				helpers.SimpleByteRange(93, 104)},
+			}, nil,
 			dagCborHTMLRendering)
 
 		RunWithSpecs(t, rangeTests, specs.PathGatewayDAG)

--- a/tests/path_gateway_dag_test.go
+++ b/tests/path_gateway_dag_test.go
@@ -236,7 +236,7 @@ func TestPlainCodec(t *testing.T) {
 
 		tests := &SugarTests{}
 		tests.Append(
-			helpers.BaseWithRangeTestTransform(t,
+			helpers.IncludeRangeTests(t,
 				SugarTest{
 					Name: Fmt(`GET {{name}} without Accept or format= has expected "{{format}}" Content-Type and body as-is`, row.Name, row.Format),
 					Hint: `
@@ -255,7 +255,7 @@ func TestPlainCodec(t *testing.T) {
 				Fmt("application/{{format}}", row.Format),
 			)...).
 			Append(
-				helpers.BaseWithRangeTestTransform(t,
+				helpers.IncludeRangeTests(t,
 					SugarTest{
 						Name: Fmt("GET {{name}} with ?format= has expected {{format}} Content-Type and body as-is", row.Name, row.Format),
 						Hint: `
@@ -275,7 +275,7 @@ func TestPlainCodec(t *testing.T) {
 					Fmt("application/{{format}}", row.Format),
 				)...).
 			Append(
-				helpers.BaseWithRangeTestTransform(t,
+				helpers.IncludeRangeTests(t,
 					SugarTest{
 						Name: Fmt("GET {{name}} with Accept has expected {{format}} Content-Type and body as-is, with single range request", row.Name, row.Format),
 						Hint: `

--- a/tests/path_gateway_dag_test.go
+++ b/tests/path_gateway_dag_test.go
@@ -761,33 +761,22 @@ func TestNativeDag(t *testing.T) {
 	}, specs.PathGatewayDAG)
 
 	if dagJsonConvertedData != nil {
-		rangeTests := SugarTests{
-			helpers.SingleRangeTestTransform(t, SugarTest{
-				Name: "Convert application/vnd.ipld.dag-cbor to application/vnd.ipld.dag-json with single range request includes correct bytes",
+		rangeTests := helpers.RangeTestTransform(
+			t,
+			SugarTest{
+				Name: "Convert application/vnd.ipld.dag-cbor to application/vnd.ipld.dag-json with range request includes correct bytes",
 				Hint: "",
 				Request: Request().
 					Path("/ipfs/{{cid}}/", dagCborCID).
 					Headers(
 						Header("Accept", "application/vnd.ipld.dag-json"),
-						Header("Range", "bytes=1-5"),
 					),
 				Response: Expect(),
-			}, helpers.SimpleByteRange(1, 5, dagJsonConvertedData[1:6]), dagJsonConvertedData),
-			helpers.MultiRangeTestTransform(t, SugarTest{
-				Name: "Convert application/vnd.ipld.dag-cbor to application/vnd.ipld.dag-json with multiple range request includes correct bytes",
-				Hint: "",
-				Request: Request().
-					Path("/ipfs/{{cid}}/", dagCborCID).
-					Headers(
-						Header("Accept", "application/vnd.ipld.dag-json"),
-						Header("Range", "bytes=1-5,93-104"),
-					),
-				Response: Expect(),
-			}, helpers.ByteRanges{
+			},
+			helpers.ByteRanges{
 				helpers.SimpleByteRange(1, 5, dagJsonConvertedData[1:6]),
 				helpers.SimpleByteRange(93, 104, dagJsonConvertedData[93:105])},
-				dagJsonConvertedData),
-		}
+			dagJsonConvertedData)
 
 		RunWithSpecs(t, rangeTests, specs.PathGatewayDAG)
 	}
@@ -814,33 +803,20 @@ func TestNativeDag(t *testing.T) {
 	}, specs.PathGatewayDAG)
 
 	if dagCborHTMLRendering != nil {
-		rangeTests := SugarTests{
-			helpers.SingleRangeTestTransform(t, SugarTest{
-				Name: "Convert application/vnd.ipld.dag-cbor to text/html with single range request includes correct bytes",
+		rangeTests := helpers.RangeTestTransform(t,
+			SugarTest{
+				Name: "Convert application/vnd.ipld.dag-cbor to text/html with range request includes correct bytes",
 				Hint: "",
 				Request: Request().
 					Path("/ipfs/{{cid}}/", dagCborCID).
 					Headers(
 						Header("Accept", "text/html"),
-						Header("Range", "bytes=1-5"),
-					),
-				Response: Expect(),
-			}, helpers.SimpleByteRange(1, 5, dagCborHTMLRendering[1:6]), dagCborHTMLRendering),
-			helpers.MultiRangeTestTransform(t, SugarTest{
-				Name: "Convert application/vnd.ipld.dag-cbor to text/html with multiple range request includes correct bytes",
-				Hint: "",
-				Request: Request().
-					Path("/ipfs/{{cid}}/", dagCborCID).
-					Headers(
-						Header("Accept", "text/html"),
-						Header("Range", "bytes=1-5,93-104"),
 					),
 				Response: Expect(),
 			}, helpers.ByteRanges{
 				helpers.SimpleByteRange(1, 5, dagCborHTMLRendering[1:6]),
 				helpers.SimpleByteRange(93, 104, dagCborHTMLRendering[93:105])},
-				dagCborHTMLRendering),
-		}
+			dagCborHTMLRendering)
 
 		RunWithSpecs(t, rangeTests, specs.PathGatewayDAG)
 	}

--- a/tests/path_gateway_dag_test.go
+++ b/tests/path_gateway_dag_test.go
@@ -248,12 +248,11 @@ func TestPlainCodec(t *testing.T) {
 						Headers(
 							Header("Content-Disposition").
 								Contains(Fmt(`{{disposition}}; filename="{{cid}}.{{format}}"`, row.Disposition, plainCID, row.Format)),
-							Header("Content-Type").
-								Contains(Fmt("application/{{format}}", row.Format)),
 						),
 				},
 				nil,
 				plain.RawData(),
+				Fmt("application/{{format}}", row.Format),
 			)...).
 			Append(
 				helpers.BaseWithRangeTestTransform(t,
@@ -269,12 +268,11 @@ func TestPlainCodec(t *testing.T) {
 							Headers(
 								Header("Content-Disposition").
 									Contains(`{{disposition}}; filename="{{cid}}.{{format}}"`, row.Disposition, plainCID, row.Format),
-								Header("Content-Type").
-									Contains("application/{{format}}", row.Format),
 							),
 					},
 					nil,
 					plain.RawData(),
+					Fmt("application/{{format}}", row.Format),
 				)...).
 			Append(
 				helpers.BaseWithRangeTestTransform(t,
@@ -292,12 +290,11 @@ func TestPlainCodec(t *testing.T) {
 							Headers(
 								Header("Content-Disposition").
 									Contains(`{{disposition}}; filename="{{cid}}.{{format}}"`, row.Disposition, plainCID, row.Format),
-								Header("Content-Type").
-									Contains("application/{{format}}", row.Format),
 							),
 					},
 					nil,
 					plain.RawData(),
+					Fmt("application/{{format}}", row.Format),
 				)...).
 			Append(
 				SugarTest{
@@ -346,12 +343,11 @@ func TestPlainCodec(t *testing.T) {
 						Headers(
 							Header("Content-Disposition").
 								Contains(`{{disposition}}; filename="{{cid}}.{{format}}"`, row.Disposition, plainOrDagCID, row.Format),
-							Header("Content-Type").
-								Contains("application/vnd.ipld.dag-{{format}}", row.Format),
 						),
 				},
 				nil,
 				dagFormattedResponse,
+				Fmt("application/vnd.ipld.dag-{{format}}", row.Format),
 			)
 			RunWithSpecs(t, rangeTests, specs.PathGatewayDAG)
 		}
@@ -626,12 +622,9 @@ func TestNativeDag(t *testing.T) {
 				Name: Fmt("GET {{name}} on /ipfs with no explicit header", row.Name),
 				Request: Request().
 					Path("/ipfs/{{cid}}/", dagTraversalCID),
-				Response: Expect().
-					Headers(
-						Header("Content-Type", "application/vnd.ipld.dag-{{format}}", row.Format),
-					),
+				Response: Expect(),
 			}, nil,
-			dagTraversal.RawData(),
+			dagTraversal.RawData(), Fmt("application/vnd.ipld.dag-{{format}}", row.Format),
 		)...).Append(
 			helpers.RangeTestTransform(t,
 				SugarTest{
@@ -641,12 +634,10 @@ func TestNativeDag(t *testing.T) {
 						Headers(
 							Header("Accept", "application/vnd.ipld.dag-{{format}}", row.Format),
 						),
-					Response: Expect().
-						Headers(
-							Header("Content-Type", "application/vnd.ipld.dag-{{format}}", row.Format),
-						),
+					Response: Expect(),
 				},
 				nil, dagTraversal.RawData(),
+				Fmt("application/vnd.ipld.dag-{{format}}", row.Format),
 			)...).Append(
 			helpers.RangeTestTransform(t,
 				SugarTest{
@@ -656,13 +647,11 @@ func TestNativeDag(t *testing.T) {
 						Headers(
 							Header("Accept", "application/{{format}}", row.Format),
 						),
-					Response: Expect().
-						Headers(
-							Header("Content-Type", "application/{{format}}", row.Format),
-						),
+					Response: Expect(),
 				},
 				nil,
 				dagTraversal.RawData(),
+				Fmt("application/{{format}}", row.Format),
 			)...)
 
 		RunWithSpecs(t, tests, specs.PathGatewayDAG)
@@ -705,7 +694,8 @@ func TestNativeDag(t *testing.T) {
 				Response: Expect(),
 			},
 			nil,
-			dagJsonConvertedData)
+			dagJsonConvertedData,
+			"application/vnd.ipld.dag-json")
 
 		RunWithSpecs(t, rangeTests, specs.PathGatewayDAG)
 	}
@@ -743,7 +733,8 @@ func TestNativeDag(t *testing.T) {
 					),
 				Response: Expect(),
 			}, nil,
-			dagCborHTMLRendering)
+			dagCborHTMLRendering,
+			"text/html")
 
 		RunWithSpecs(t, rangeTests, specs.PathGatewayDAG)
 	}

--- a/tests/trustless_gateway_raw_test.go
+++ b/tests/trustless_gateway_raw_test.go
@@ -1,10 +1,11 @@
 package tests
 
 import (
-	"github.com/ipfs/gateway-conformance/tooling/helpers"
 	"strconv"
 	"strings"
 	"testing"
+
+	"github.com/ipfs/gateway-conformance/tooling/helpers"
 
 	"github.com/ipfs/gateway-conformance/tooling"
 	"github.com/ipfs/gateway-conformance/tooling/car"
@@ -140,7 +141,7 @@ func TestTrustlessRawRanges(t *testing.T) {
 	// correctly.
 	fixture := car.MustOpenUnixfsCar("gateway-raw-block.car")
 
-	tests := helpers.RangeTestTransform(t,
+	tests := helpers.OnlyRandomRangeTests(t,
 		SugarTest{
 			Name: "GET with application/vnd.ipld.raw with range request includes correct bytes",
 			Request: Request().
@@ -150,7 +151,6 @@ func TestTrustlessRawRanges(t *testing.T) {
 				),
 			Response: Expect(),
 		},
-		nil,
 		fixture.MustGetRawData("dir", "ascii.txt"),
 		"application/vnd.ipld.raw",
 	)

--- a/tests/trustless_gateway_raw_test.go
+++ b/tests/trustless_gateway_raw_test.go
@@ -151,10 +151,10 @@ func TestTrustlessRawRanges(t *testing.T) {
 			Response: Expect(),
 		},
 		helpers.ByteRanges{
-			helpers.SimpleByteRange(6, 16, fixture.MustGetRawData("dir", "ascii.txt")[6:17]),
-			helpers.SimpleByteRange(0, 4, fixture.MustGetRawData("dir", "ascii.txt")[0:5]),
+			helpers.SimpleByteRange(6, 16),
+			helpers.SimpleByteRange(0, 4),
 		},
 		fixture.MustGetRawData("dir", "ascii.txt"))
-	
+
 	RunWithSpecs(t, tests, specs.TrustlessGatewayRaw)
 }

--- a/tests/trustless_gateway_raw_test.go
+++ b/tests/trustless_gateway_raw_test.go
@@ -151,7 +151,9 @@ func TestTrustlessRawRanges(t *testing.T) {
 			Response: Expect(),
 		},
 		nil,
-		fixture.MustGetRawData("dir", "ascii.txt"))
+		fixture.MustGetRawData("dir", "ascii.txt"),
+		"application/vnd.ipld.raw",
+	)
 
 	RunWithSpecs(t, tests, specs.TrustlessGatewayRaw)
 }

--- a/tests/trustless_gateway_raw_test.go
+++ b/tests/trustless_gateway_raw_test.go
@@ -140,32 +140,13 @@ func TestTrustlessRawRanges(t *testing.T) {
 	// correctly.
 	fixture := car.MustOpenUnixfsCar("gateway-raw-block.car")
 
-	singleRangeTest := helpers.SingleRangeTestTransform(t,
+	tests := helpers.RangeTestTransform(t,
 		SugarTest{
-			Name: "GET with application/vnd.ipld.raw with single range request includes correct bytes",
+			Name: "GET with application/vnd.ipld.raw with range request includes correct bytes",
 			Request: Request().
 				Path("/ipfs/{{cid}}", fixture.MustGetCid("dir", "ascii.txt")).
 				Headers(
 					Header("Accept", "application/vnd.ipld.raw"),
-					Header("Range", "bytes=6-16"),
-				),
-			Response: Expect().
-				Headers(
-					Header("Content-Type").Contains("application/vnd.ipld.raw"),
-				),
-		},
-		helpers.SimpleByteRange(6, 16, fixture.MustGetRawData("dir", "ascii.txt")[6:17]),
-		fixture.MustGetRawData("dir", "ascii.txt"),
-	)
-
-	multiRangeTest := helpers.MultiRangeTestTransform(t,
-		SugarTest{
-			Name: "GET with application/vnd.ipld.raw with multiple range request includes correct bytes",
-			Request: Request().
-				Path("/ipfs/{{cid}}", fixture.MustGetCid("dir", "ascii.txt")).
-				Headers(
-					Header("Accept", "application/vnd.ipld.raw"),
-					Header("Range", "bytes=6-16,0-4"),
 				),
 			Response: Expect(),
 		},
@@ -173,13 +154,7 @@ func TestTrustlessRawRanges(t *testing.T) {
 			helpers.SimpleByteRange(6, 16, fixture.MustGetRawData("dir", "ascii.txt")[6:17]),
 			helpers.SimpleByteRange(0, 4, fixture.MustGetRawData("dir", "ascii.txt")[0:5]),
 		},
-		fixture.MustGetRawData("dir", "ascii.txt"),
-	)
-
-	tests := SugarTests{
-		singleRangeTest,
-		multiRangeTest,
-	}
-
+		fixture.MustGetRawData("dir", "ascii.txt"))
+	
 	RunWithSpecs(t, tests, specs.TrustlessGatewayRaw)
 }

--- a/tests/trustless_gateway_raw_test.go
+++ b/tests/trustless_gateway_raw_test.go
@@ -150,10 +150,7 @@ func TestTrustlessRawRanges(t *testing.T) {
 				),
 			Response: Expect(),
 		},
-		helpers.ByteRanges{
-			helpers.SimpleByteRange(6, 16),
-			helpers.SimpleByteRange(0, 4),
-		},
+		nil,
 		fixture.MustGetRawData("dir", "ascii.txt"))
 
 	RunWithSpecs(t, tests, specs.TrustlessGatewayRaw)

--- a/tooling/helpers/car.go
+++ b/tooling/helpers/car.go
@@ -18,7 +18,11 @@ func StandardCARTestTransforms(t *testing.T, sts test.SugarTests) test.SugarTest
 }
 
 func applyStandardCarResponseHeaders(t *testing.T, st test.SugarTest) test.SugarTest {
-	st.Response = st.Response.Headers(
+	resp, ok := st.Response.(test.ExpectBuilder)
+	if !ok {
+		t.Fatal("can only apply test transformation on an ExpectBuilder")
+	}
+	st.Response = resp.Headers(
 		// TODO: Go always sends Content-Length and it's not possible to explicitly disable the behavior.
 		// For now, we ignore this check. It should be able to be resolved soon: https://github.com/ipfs/boxo/pull/177
 		// test.Header("Content-Length").

--- a/tooling/helpers/range.go
+++ b/tooling/helpers/range.go
@@ -177,7 +177,7 @@ func MultiRangeTestTransform(t *testing.T, baseTest test.SugarTest, branges Byte
 	return rangeTest
 }
 
-// BaseWithRangeTestTransform takes a test where there is no "Range" header set in the request, or checks on the
+// IncludeRangeTests takes a test where there is no "Range" header set in the request, or checks on the
 // StatusCode, Body, or Content-Range headers and verifies whether a valid response is given for the requested ranges.
 // Will test the full request, a single range request for the first passed range as well as a multi-range request for
 // all the requested ranges.
@@ -185,12 +185,12 @@ func MultiRangeTestTransform(t *testing.T, baseTest test.SugarTest, branges Byte
 // If contentType is empty it is ignored.
 //
 // If no ranges are passed then some non-overlapping ranges are automatically generated for data >= 10 bytes. Smaller
-// data will result in undefined behavior.
+// data will produce a panic to avoid undefined behavior.
 //
 // Note: HTTP Range requests can be validly responded with either the full data, or the requested partial data
 // Note: HTTP Multi Range requests can be validly responded with one of the full data, the partial data from the first
 // range, or the partial data from all the requested ranges
-func BaseWithRangeTestTransform(t *testing.T, baseTest test.SugarTest, branges ByteRanges, fullData []byte, contentType string) test.SugarTests {
+func IncludeRangeTests(t *testing.T, baseTest test.SugarTest, branges ByteRanges, fullData []byte, contentType string) test.SugarTests {
 	standardBaseRequest := baseTest.Request.Clone()
 	if contentType != "" {
 		standardBaseRequest = standardBaseRequest.Header("Content-Type", contentType)
@@ -218,7 +218,7 @@ func BaseWithRangeTestTransform(t *testing.T, baseTest test.SugarTest, branges B
 // If contentType is empty it is ignored.
 //
 // If no ranges are passed then some non-overlapping ranges are automatically generated for data >= 10 bytes. Smaller
-// data will result in undefined behavior.
+// data will produce a panic to avoid undefined behavior.
 //
 // Note: HTTP Range requests can be validly responded with either the full data, or the requested partial data
 // Note: HTTP Multi Range requests can be validly responded with one of the full data, the partial data from the first

--- a/tooling/helpers/range.go
+++ b/tooling/helpers/range.go
@@ -1,0 +1,176 @@
+package helpers
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/ipfs/gateway-conformance/tooling/check"
+	"github.com/ipfs/gateway-conformance/tooling/test"
+)
+
+// ByteRange describes an HTTP range request and the data it corresponds to. "From" and "To" mostly
+// follow [HTTP Byte Range] Request semantics:
+//
+//   - From >= 0 and To = nil: Get the file (From, Length)
+//   - From >= 0 and To >= 0: Get the range (From, To)
+//   - From >= 0 and To <0: Get the range (From, Length - To)
+//
+// [HTTP Byte Range]: https://httpwg.org/specs/rfc9110.html#rfc.section.14.1.2
+type ByteRange struct {
+	From       uint64
+	To         *int64
+	RangeBytes []byte
+}
+
+func SimpleByteRange(from, to uint64, data []byte) ByteRange {
+	toInt := int64(to)
+	return ByteRange{
+		From:       from,
+		To:         &toInt,
+		RangeBytes: data,
+	}
+}
+
+func (b ByteRange) GetRangeString(t *testing.T) string {
+	strWithoutPrefix := b.getRangeStringWithoutPrefix(t)
+	return fmt.Sprintf("bytes=%s", strWithoutPrefix)
+}
+
+func (b ByteRange) getRangeStringWithoutPrefix(t *testing.T) string {
+	if b.To == nil {
+		return fmt.Sprintf("%d-", b.From)
+	}
+
+	to := *b.To
+	if to >= 0 {
+		return fmt.Sprintf("%d-%d", b.From, to)
+	}
+
+	if to < 0 && b.From != 0 {
+		t.Fatalf("for a suffix request the From field must be 0")
+	}
+	return fmt.Sprintf("%d", to)
+}
+
+func (b ByteRange) getRange(t *testing.T, totalSize int64) (uint64, uint64) {
+	if totalSize < 0 {
+		t.Fatalf("total size must be greater than 0")
+	}
+
+	if b.To == nil {
+		return b.From, uint64(totalSize)
+	}
+
+	to := *b.To
+	if to >= 0 {
+		return b.From, uint64(to)
+	}
+
+	if to < 0 && b.From != 0 {
+		t.Fatalf("for a suffix request the From field must be 0")
+	}
+
+	start := int64(totalSize) + to
+	if start < 0 {
+		t.Fatalf("suffix request must not start before the start of the file")
+	}
+
+	return uint64(start), uint64(totalSize)
+}
+
+type ByteRanges []ByteRange
+
+func (b ByteRanges) GetRangeString(t *testing.T) string {
+	var rangeStrs []string
+	for _, r := range b {
+		rangeStrs = append(rangeStrs, r.getRangeStringWithoutPrefix(t))
+	}
+	return fmt.Sprintf("bytes=%s", strings.Join(rangeStrs, ","))
+}
+
+// SingleRangeTestTransform takes a test where there is no "Range" header set in the request, or checks on the
+// StatusCode, Body, or Content-Range headers and verifies whether a valid response is given for the requested range.
+//
+// Note: HTTP Range requests can be validly responded with either the full data, or the requested partial data
+func SingleRangeTestTransform(t *testing.T, baseTest test.SugarTest, brange ByteRange, fullData []byte) test.SugarTest {
+	modifiedRequest := baseTest.Request.Clone().Header("Range", brange.GetRangeString(t))
+	if baseTest.Requests != nil {
+		t.Fatal("does not support multiple requests or responses")
+	}
+
+	fullSize := int64(len(fullData))
+	start, end := brange.getRange(t, fullSize)
+
+	rangeTest := test.SugarTest{
+		Name:     baseTest.Name,
+		Hint:     baseTest.Hint,
+		Request:  modifiedRequest,
+		Requests: nil,
+		Response: test.AllOf(
+			baseTest.Response,
+			test.AnyOf(
+				test.Expect().Status(http.StatusPartialContent).Body(brange.RangeBytes).Headers(
+					test.Header("Content-Range").Equals("bytes {{start}}-{{end}}/{{length}}", start, end, fullSize),
+				),
+				test.Expect().Status(http.StatusOK).Body(fullData),
+			),
+		),
+		Responses: baseTest.Responses,
+	}
+
+	return rangeTest
+}
+
+// MultiRangeTestTransform takes a test where there is no "Range" header set in the request, or checks on the
+// StatusCode, Body, or Content-Range headers and verifies whether a valid response is given for the requested ranges.
+//
+// Note: HTTP Multi Range requests can be validly responded with one of the full data, the partial data from the first
+// range, or the partial data from all the requested ranges
+func MultiRangeTestTransform(t *testing.T, testWithoutRangeRequestHeader test.SugarTest, branges ByteRanges, fullData []byte) test.SugarTest {
+	modifiedRequest := testWithoutRangeRequestHeader.Request.Clone().Header("Range", branges.GetRangeString(t))
+	if testWithoutRangeRequestHeader.Requests != nil {
+		t.Fatal("does not support multiple requests or responses")
+	}
+
+	fullSize := int64(len(fullData))
+	type rng struct {
+		start, end uint64
+	}
+
+	var multirangeBodyChecks []check.Check[string]
+	var ranges []rng
+	for _, r := range branges {
+		start, end := r.getRange(t, fullSize)
+		ranges = append(ranges, rng{start: start, end: end})
+		multirangeBodyChecks = append(multirangeBodyChecks,
+			check.Contains("Content-Range: bytes {{start}}-{{end}}/{{length}}", ranges[0].start, ranges[0].end, fullSize),
+			check.Contains(string(r.RangeBytes)),
+		)
+	}
+
+	rangeTest := test.SugarTest{
+		Name:     testWithoutRangeRequestHeader.Name,
+		Hint:     testWithoutRangeRequestHeader.Hint,
+		Request:  modifiedRequest,
+		Requests: nil,
+		Response: test.AllOf(
+			testWithoutRangeRequestHeader.Response,
+			test.AnyOf(
+				test.Expect().Status(http.StatusOK).Body(fullData),
+				test.Expect().Status(http.StatusPartialContent).Body(branges[0].RangeBytes).Headers(
+					test.Header("Content-Range").Equals("bytes {{start}}-{{end}}/{{length}}", ranges[0].start, ranges[0].end, fullSize),
+				),
+				test.Expect().Status(http.StatusPartialContent).Body(
+					check.And(
+						append([]check.Check[string]{check.Contains("Content-Type: application/vnd.ipld.raw")}, multirangeBodyChecks...)...,
+					),
+				).Headers(test.Header("Content-Type").Contains("multipart/byteranges")),
+			),
+		),
+		Responses: testWithoutRangeRequestHeader.Responses,
+	}
+
+	return rangeTest
+}

--- a/tooling/helpers/range.go
+++ b/tooling/helpers/range.go
@@ -175,6 +175,30 @@ func MultiRangeTestTransform(t *testing.T, testWithoutRangeRequestHeader test.Su
 	return rangeTest
 }
 
+// BaseWithRangeTestTransform takes a test where there is no "Range" header set in the request, or checks on the
+// StatusCode, Body, or Content-Range headers and verifies whether a valid response is given for the requested ranges.
+// Will test the full request, a single range request for the first passed range as well as a multi-range request for
+// all the requested ranges.
+//
+// Note: HTTP Range requests can be validly responded with either the full data, or the requested partial data
+// Note: HTTP Multi Range requests can be validly responded with one of the full data, the partial data from the first
+// range, or the partial data from all the requested ranges
+func BaseWithRangeTestTransform(t *testing.T, baseTest test.SugarTest, branges ByteRanges, fullData []byte) test.SugarTests {
+	standardBase := test.SugarTest{
+		Name:     fmt.Sprintf("%s - full request", baseTest.Name),
+		Hint:     baseTest.Hint,
+		Request:  baseTest.Request,
+		Requests: baseTest.Requests,
+		Response: test.AllOf(
+			baseTest.Response,
+			test.Expect().Status(http.StatusOK).Body(fullData),
+		),
+		Responses: baseTest.Responses,
+	}
+	rangeTests := RangeTestTransform(t, baseTest, branges, fullData)
+	return append(test.SugarTests{standardBase}, rangeTests...)
+}
+
 // RangeTestTransform takes a test where there is no "Range" header set in the request, or checks on the
 // StatusCode, Body, or Content-Range headers and verifies whether a valid response is given for the requested ranges.
 // Will test both a single range request for the first passed range as well as a multi-range request for all the

--- a/tooling/helpers/range.go
+++ b/tooling/helpers/range.go
@@ -126,12 +126,12 @@ func SingleRangeTestTransform(t *testing.T, baseTest test.SugarTest, brange Byte
 //
 // Note: HTTP Multi Range requests can be validly responded with one of the full data, the partial data from the first
 // range, or the partial data from all the requested ranges
-func MultiRangeTestTransform(t *testing.T, testWithoutRangeRequestHeader test.SugarTest, branges ByteRanges, fullData []byte) test.SugarTest {
-	modifiedRequest := testWithoutRangeRequestHeader.Request.Clone().Header("Range", branges.GetRangeString(t))
-	if testWithoutRangeRequestHeader.Requests != nil {
+func MultiRangeTestTransform(t *testing.T, baseTest test.SugarTest, branges ByteRanges, fullData []byte) test.SugarTest {
+	modifiedRequest := baseTest.Request.Clone().Header("Range", branges.GetRangeString(t))
+	if baseTest.Requests != nil {
 		t.Fatal("does not support multiple requests or responses")
 	}
-	modifiedResponse := testWithoutRangeRequestHeader.Response.Clone()
+	modifiedResponse := baseTest.Response.Clone()
 
 	fullSize := int64(len(fullData))
 	type rng struct {
@@ -150,8 +150,8 @@ func MultiRangeTestTransform(t *testing.T, testWithoutRangeRequestHeader test.Su
 	}
 
 	rangeTest := test.SugarTest{
-		Name:     testWithoutRangeRequestHeader.Name,
-		Hint:     testWithoutRangeRequestHeader.Hint,
+		Name:     baseTest.Name,
+		Hint:     baseTest.Hint,
 		Request:  modifiedRequest,
 		Requests: nil,
 		Response: test.AllOf(

--- a/tooling/helpers/range.go
+++ b/tooling/helpers/range.go
@@ -178,6 +178,9 @@ func MultiRangeTestTransform(t *testing.T, testWithoutRangeRequestHeader test.Su
 // Will test the full request, a single range request for the first passed range as well as a multi-range request for
 // all the requested ranges.
 //
+// If no ranges are passed then some non-overlapping ranges are automatically generated for data >= 10 bytes. Smaller
+// data will result in undefined behavior.
+//
 // Note: HTTP Range requests can be validly responded with either the full data, or the requested partial data
 // Note: HTTP Multi Range requests can be validly responded with one of the full data, the partial data from the first
 // range, or the partial data from all the requested ranges
@@ -202,10 +205,25 @@ func BaseWithRangeTestTransform(t *testing.T, baseTest test.SugarTest, branges B
 // Will test both a single range request for the first passed range as well as a multi-range request for all the
 // requested ranges.
 //
+// If no ranges are passed then some non-overlapping ranges are automatically generated for data >= 10 bytes. Smaller
+// data will result in undefined behavior.
+//
 // Note: HTTP Range requests can be validly responded with either the full data, or the requested partial data
 // Note: HTTP Multi Range requests can be validly responded with one of the full data, the partial data from the first
 // range, or the partial data from all the requested ranges
 func RangeTestTransform(t *testing.T, baseTest test.SugarTest, branges ByteRanges, fullData []byte) test.SugarTests {
+	if len(branges) == 0 {
+		dataLen := len(fullData)
+		if dataLen < 10 {
+			panic("transformation not defined for data smaller than 10 bytes")
+		}
+
+		branges = ByteRanges{
+			SimpleByteRange(7, 9),
+			SimpleByteRange(1, 3),
+		}
+	}
+
 	singleBase := test.SugarTest{
 		Name:      fmt.Sprintf("%s - single range", baseTest.Name),
 		Hint:      baseTest.Hint,

--- a/tooling/test/sugar.go
+++ b/tooling/test/sugar.go
@@ -1,6 +1,7 @@
 package test
 
 import (
+	"fmt"
 	"net/http"
 	"net/url"
 	"testing"
@@ -261,8 +262,11 @@ func AllOf(expect ...ExpectValidator) AllOfExpectBuilder {
 func (e AllOfExpectBuilder) Validate(t *testing.T, res *http.Response, localReport Reporter) {
 	t.Helper()
 
-	for _, expect := range e.Expect_ {
-		expect.Validate(t, res, localReport)
+	for i, expect := range e.Expect_ {
+		t.Run(
+			fmt.Sprintf("Check %d", i), func(t *testing.T) {
+				expect.Validate(t, res, localReport)
+			})
 	}
 }
 

--- a/tooling/test/sugar.go
+++ b/tooling/test/sugar.go
@@ -254,7 +254,7 @@ func (e ExpectBuilder) Validate(t *testing.T, res *http.Response, localReport Re
 }
 
 // Clone performs a deep clone of the ExpectBuilder
-// Note: if there are unclonable components like [check.Check]s used in the inner header or body this will panic
+// Note: if there are [check.Check]s used in the inner header or body components those are only shallowly cloned
 func (e ExpectBuilder) Clone() ExpectValidator {
 	clone := ExpectBuilder{}
 	var clonedHeaders []HeaderBuilder
@@ -273,8 +273,16 @@ func (e ExpectBuilder) Clone() ExpectValidator {
 		clone.Body_ = body
 	case []byte:
 		clone.Body_ = body[:]
+	case check.CheckWithHint[string]:
+		clone.Body_ = body
+	case check.CheckWithHint[[]byte]:
+		clone.Body_ = body
+	case check.Check[string]:
+		clone.Body_ = body
+	case check.Check[[]byte]:
+		clone.Body_ = body
 	default:
-		panic("body must be string or []byte")
+		panic("body must be string, []byte, or a regular check")
 	}
 	return clone
 }
@@ -301,8 +309,8 @@ func (e AllOfExpectBuilder) Validate(t *testing.T, res *http.Response, localRepo
 }
 
 // Clone performs a deep clone of the AllOfExpectBuilder
-// Note: if there are unclonable components like [check.Check]s used in the header or body of the nested builders
-// this will panic
+// Note: if there are [check.Check]s used in the header or body components of the nested builders those are only
+// shallowly cloned
 func (e AllOfExpectBuilder) Clone() ExpectValidator {
 	var clonedInnerValidators []ExpectValidator
 	for _, eb := range e.Expect_ {
@@ -363,8 +371,8 @@ func (e AnyOfExpectBuilder) Validate(t *testing.T, res *http.Response, localRepo
 }
 
 // Clone performs a deep clone of the AnyOfExpectBuilder
-// Note: if there are unclonable components like [check.Check]s used in the header or body of the nested builders
-// this will panic
+// Note: if there are [check.Check]s used in the header or body components of the nested builders those are only
+// shallowly cloned
 func (e AnyOfExpectBuilder) Clone() ExpectValidator {
 	var clonedInnerBuilders []ExpectBuilder
 	for _, eb := range e.Expect_ {
@@ -460,13 +468,9 @@ func (h HeaderBuilder) Exists() HeaderBuilder {
 	return h.Not().IsEmpty()
 }
 
-// Clone performs a deep clone of the HeaderBuilder
-// Note: if the Check_ field is not nil this will panic since that field cannot be deep cloned
+// Clone performs a shallow clone of the HeaderBuilder
+// Note: The Check field is an interface and as a result is just copied
 func (h HeaderBuilder) Clone() HeaderBuilder {
-	if h.Check_ != nil {
-		panic("cannot clone a HeaderBuilder with a non-nil Check")
-	}
-
 	clone := HeaderBuilder{
 		Key_:   h.Key_,
 		Value_: h.Key_,

--- a/tooling/test/sugar.go
+++ b/tooling/test/sugar.go
@@ -264,6 +264,10 @@ func (e ExpectBuilder) Clone() ExpectValidator {
 	clone.StatusCode_ = e.StatusCode_
 	clone.Headers_ = clonedHeaders
 
+	if e.Body_ == nil {
+		return clone
+	}
+
 	switch body := e.Body_.(type) {
 	case string:
 		clone.Body_ = body

--- a/tooling/test/sugar.go
+++ b/tooling/test/sugar.go
@@ -148,6 +148,8 @@ type ExpectBuilder struct {
 	Specs_          []string        `json:"specs,omitempty"`
 }
 
+var _ ExpectValidator = (*ExpectBuilder)(nil)
+
 func Expect() ExpectBuilder {
 	return ExpectBuilder{Body_: nil}
 }
@@ -246,9 +248,29 @@ func (e ExpectBuilder) Validate(t *testing.T, res *http.Response, localReport Re
 	}
 }
 
+type AllOfExpectBuilder struct {
+	Expect_ []ExpectValidator `json:"expect,omitempty"`
+}
+
+var _ ExpectValidator = (*AllOfExpectBuilder)(nil)
+
+func AllOf(expect ...ExpectValidator) AllOfExpectBuilder {
+	return AllOfExpectBuilder{Expect_: expect}
+}
+
+func (e AllOfExpectBuilder) Validate(t *testing.T, res *http.Response, localReport Reporter) {
+	t.Helper()
+
+	for _, expect := range e.Expect_ {
+		expect.Validate(t, res, localReport)
+	}
+}
+
 type AnyOfExpectBuilder struct {
 	Expect_ []ExpectBuilder `json:"expect,omitempty"`
 }
+
+var _ ExpectValidator = (*AnyOfExpectBuilder)(nil)
 
 func AnyOf(expect ...ExpectBuilder) AnyOfExpectBuilder {
 	return AnyOfExpectBuilder{Expect_: expect}

--- a/tooling/test/sugar.go
+++ b/tooling/test/sugar.go
@@ -6,6 +6,7 @@ import (
 	"net/url"
 	"testing"
 
+	"github.com/ipfs/gateway-conformance/tooling"
 	"github.com/ipfs/gateway-conformance/tooling/check"
 	"github.com/ipfs/gateway-conformance/tooling/tmpl"
 )
@@ -239,10 +240,12 @@ func (e ExpectBuilder) BodyWithHint(hint string, body interface{}) ExpectBuilder
 
 func (e ExpectBuilder) Validate(t *testing.T, res *http.Response, localReport Reporter) {
 	t.Helper()
+	tooling.LogSpecs(t, e.Specs_...)
 
 	checks := validateResponse(t, e, res)
 	for _, c := range checks {
 		t.Run(c.testName, func(t *testing.T) {
+			tooling.LogSpecs(t, c.specs...)
 			if !c.checkOutput.Success {
 				localReport(t, c.checkOutput.Reason)
 			}

--- a/tooling/test/test.go
+++ b/tooling/test/test.go
@@ -25,8 +25,8 @@ type SugarTest struct {
 
 type SugarTests []SugarTest
 
-func (s *SugarTests) Append(tests ...SugarTest) *SugarTests {
-	*s = append(*s, tests...)
+func (s SugarTests) Append(tests ...SugarTest) SugarTests {
+	s = append(s, tests...)
 	return s
 }
 

--- a/tooling/test/test.go
+++ b/tooling/test/test.go
@@ -19,7 +19,7 @@ type SugarTest struct {
 	Specs     []string
 	Request   RequestBuilder
 	Requests  []RequestBuilder
-	Response  ExpectBuilder
+	Response  ExpectValidator
 	Responses ExpectsBuilder
 }
 
@@ -79,7 +79,9 @@ func run(t *testing.T, tests SugarTests) {
 
 				for _, req := range test.Requests {
 					_, res, localReport := runRequest(timeout, t, test, req)
-					validateResponse(t, test.Response, res, localReport)
+					if test.Response != nil {
+						test.Response.Validate(t, res, localReport)
+					}
 					responses = append(responses, res)
 				}
 
@@ -89,7 +91,9 @@ func run(t *testing.T, tests SugarTests) {
 			t.Run(name, func(t *testing.T) {
 				tooling.LogSpecs(t, test.AllSpecs()...)
 				_, res, localReport := runRequest(timeout, t, test, test.Request)
-				validateResponse(t, test.Response, res, localReport)
+				if test.Response != nil {
+					test.Response.Validate(t, res, localReport)
+				}
 			})
 		}
 	}

--- a/tooling/test/test.go
+++ b/tooling/test/test.go
@@ -25,6 +25,11 @@ type SugarTest struct {
 
 type SugarTests []SugarTest
 
+func (s *SugarTests) Append(tests ...SugarTest) *SugarTests {
+	*s = append(*s, tests...)
+	return s
+}
+
 func (s *SugarTest) AllSpecs() []string {
 	if len(s.Specs) > 0 && s.Spec != "" {
 		panic("cannot have both Spec and Specs")

--- a/tooling/test/validate.go
+++ b/tooling/test/validate.go
@@ -1,6 +1,7 @@
 package test
 
 import (
+	"bytes"
 	"fmt"
 	"io"
 	"net/http"
@@ -67,6 +68,7 @@ func validateResponse(
 			outputs = append(outputs, testCheckOutput{testName: "Body", checkOutput: check.CheckOutput{Success: false, Reason: err.Error()}})
 			return outputs
 		}
+		res.Body = io.NopCloser(bytes.NewBuffer(resBody))
 
 		var output check.CheckOutput
 

--- a/tooling/test/validate.go
+++ b/tooling/test/validate.go
@@ -10,85 +10,93 @@ import (
 	"github.com/ipfs/gateway-conformance/tooling/check"
 )
 
+type testCheckOutput struct {
+	testName    string
+	checkOutput check.CheckOutput
+}
+
 func validateResponse(
 	t *testing.T,
 	expected ExpectBuilder,
 	res *http.Response,
-	localReport Reporter,
-) {
+) []testCheckOutput {
 	t.Helper()
-	tooling.LogSpecs(t, expected.Specs_...)
+
+	var outputs []testCheckOutput
 
 	if expected.StatusCode_ != 0 {
-		t.Run("Status code", func(t *testing.T) {
-			if res.StatusCode != expected.StatusCode_ {
-				localReport(t, "Status code is not %d. It is %d", expected.StatusCode_, res.StatusCode)
-			}
-		})
-	} else if expected.StatusCodeFrom_ != 0 && expected.StatusCodeTo_ != 0 {
-		t.Run("Status code", func(t *testing.T) {
-			if res.StatusCode < expected.StatusCodeFrom_ || res.StatusCode > expected.StatusCodeTo_ {
-				localReport(t, "Status code is not between %d and %d. It is %d", expected.StatusCodeFrom_, expected.StatusCodeTo_, res.StatusCode)
-			}
-		})
+		output := testCheckOutput{testName: "Status code", checkOutput: check.CheckOutput{Success: true}}
+		if res.StatusCode != expected.StatusCode_ {
+			output.checkOutput.Success = false
+			output.checkOutput.Reason = fmt.Sprintf("Status code is not %d. It is %d", expected.StatusCode_, res.StatusCode)
+		}
+		outputs = append(outputs, output)
+	}  else if expected.StatusCodeFrom_ != 0 && expected.StatusCodeTo_ != 0 {
+		output := testCheckOutput{testName: "Status code", checkOutput: check.CheckOutput{Success: true}}
+		if res.StatusCode < expected.StatusCodeFrom_ || res.StatusCode > expected.StatusCodeTo_ {
+			output.checkOutput.Success = false
+			output.checkOutput.Reason = fmt.Sprintf("Status code is not between %d and %d. It is %d", expected.StatusCodeFrom_, expected.StatusCodeTo_, res.StatusCode)
+		}
 	}
 
 	for _, header := range expected.Headers_ {
-		t.Run(fmt.Sprintf("Header %s", header.Key_), func(t *testing.T) {
-			tooling.LogSpecs(t, header.Specs_...)
-			actual := res.Header.Values(header.Key_)
+		testName := fmt.Sprintf("Header %s", header.Key_)
+		actual := res.Header.Values(header.Key_)
 
-			c := header.Check_
-			if header.Not_ {
-				c = check.Not(c)
-			}
-			output := c.Check(actual)
+		c := header.Check_
+		if header.Not_ {
+			c = check.Not(c)
+		}
+		output := c.Check(actual)
 
-			if !output.Success {
-				if header.Hint_ == "" {
-					localReport(t, "Header '%s' %s", header.Key_, output.Reason)
-				} else {
-					localReport(t, "Header '%s' %s (%s)", header.Key_, output.Reason, header.Hint_)
-				}
+		if !output.Success {
+			if header.Hint_ == "" {
+				output.Reason = fmt.Sprintf("Header '%s' %s", header.Key_, output.Reason)
+			} else {
+				output.Reason = fmt.Sprintf("Header '%s' %s (%s)", header.Key_, output.Reason, header.Hint_)
 			}
-		})
+		}
+
+		outputs = append(outputs, testCheckOutput{testName: testName, checkOutput: output})
 	}
 
 	if expected.Body_ != nil {
-		t.Run("Body", func(t *testing.T) {
-			defer res.Body.Close()
-			resBody, err := io.ReadAll(res.Body)
-			if err != nil {
-				localReport(t, err)
-			}
+		defer res.Body.Close()
+		resBody, err := io.ReadAll(res.Body)
+		if err != nil {
+			outputs = append(outputs, testCheckOutput{testName: "Body", checkOutput: check.CheckOutput{Success: false, Reason: err.Error()}})
+			return outputs
+		}
 
-			var output check.CheckOutput
+		var output check.CheckOutput
 
-			switch v := expected.Body_.(type) {
-			case check.Check[string]:
-				output = v.Check(string(resBody))
-			case check.Check[[]byte]:
-				output = v.Check(resBody)
-			case string:
-				output = check.IsEqual(v).Check(string(resBody))
-			case []byte:
-				output = check.IsEqualBytes(v).Check(resBody)
-			default:
-				output = check.CheckOutput{
-					Success: false,
-					Reason:  fmt.Sprintf("Body check has an invalid type: %T", expected.Body_),
-				}
+		switch v := expected.Body_.(type) {
+		case check.Check[string]:
+			output = v.Check(string(resBody))
+		case check.Check[[]byte]:
+			output = v.Check(resBody)
+		case string:
+			output = check.IsEqual(v).Check(string(resBody))
+		case []byte:
+			output = check.IsEqualBytes(v).Check(resBody)
+		default:
+			output = check.CheckOutput{
+				Success: false,
+				Reason:  fmt.Sprintf("Body check has an invalid type: %T", expected.Body_),
 			}
+		}
 
-			if !output.Success {
-				if output.Hint == "" {
-					localReport(t, "Body %s", output.Reason)
-				} else {
-					localReport(t, "Body %s (%s)", output.Reason, output.Hint)
-				}
+		if !output.Success {
+			if output.Hint == "" {
+				output.Reason = fmt.Sprintf("Body %s", output.Reason)
+			} else {
+				output.Reason = fmt.Sprintf("Body %s (%s)", output.Reason, output.Hint)
 			}
-		})
+		}
+
+		outputs = append(outputs, testCheckOutput{testName: "Body", checkOutput: output})
 	}
+	return outputs
 }
 
 func readPayload(res *http.Response) ([]byte, error) {

--- a/tooling/test/validate.go
+++ b/tooling/test/validate.go
@@ -7,12 +7,12 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/ipfs/gateway-conformance/tooling"
 	"github.com/ipfs/gateway-conformance/tooling/check"
 )
 
 type testCheckOutput struct {
 	testName    string
+	specs       []string
 	checkOutput check.CheckOutput
 }
 
@@ -32,7 +32,7 @@ func validateResponse(
 			output.checkOutput.Reason = fmt.Sprintf("Status code is not %d. It is %d", expected.StatusCode_, res.StatusCode)
 		}
 		outputs = append(outputs, output)
-	}  else if expected.StatusCodeFrom_ != 0 && expected.StatusCodeTo_ != 0 {
+	} else if expected.StatusCodeFrom_ != 0 && expected.StatusCodeTo_ != 0 {
 		output := testCheckOutput{testName: "Status code", checkOutput: check.CheckOutput{Success: true}}
 		if res.StatusCode < expected.StatusCodeFrom_ || res.StatusCode > expected.StatusCodeTo_ {
 			output.checkOutput.Success = false
@@ -58,7 +58,7 @@ func validateResponse(
 			}
 		}
 
-		outputs = append(outputs, testCheckOutput{testName: testName, checkOutput: output})
+		outputs = append(outputs, testCheckOutput{testName: testName, checkOutput: output, specs: header.Specs_})
 	}
 
 	if expected.Body_ != nil {


### PR DESCRIPTION
- Add tests for #154 
- Adds basic `AnyOf` and `AllOf` helpers (related to #153)
- Range request helpers
- Added range requests tests for IPLD block requests

cc @laurentsenta @lidel 