### PR TITLE
feat: with specs dashboard

### DIFF
--- a/munge_sql.js
+++ b/munge_sql.js
@@ -100,6 +100,28 @@ const main = async () => {
         );
     `)
 
+    // Create the SPECS
+    await run(`
+    CREATE TABLE IF NOT EXISTS TestSpecs (
+        test_run_implementation_id TEXT,
+        test_run_version TEXT,
+        test_full_name TEXT,
+
+        spec_url TEXT,
+
+        PRIMARY KEY (test_run_implementation_id, test_run_version, test_full_name, spec_url),
+
+        -- test run
+        FOREIGN KEY (test_run_implementation_id, test_run_version)
+            REFERENCES TestRun (implementation_id, version),
+
+        -- test result
+        FOREIGN KEY (test_run_implementation_id, test_run_version, test_full_name)
+            REFERENCES TestResult (test_run_implementation_id, test_run_version, full_name)
+    );
+    `);
+
+
     for (const file of files) {
         const fileName = file.split("/").slice(-1)[0].split(".")[0];
         const implemId = fileName;
@@ -146,6 +168,13 @@ const main = async () => {
                 VALUES (?, ?, ?, ?)
             `, [implemId, version, fullName, test.output]);
 
+            const specsArray = test.meta?.specs || [];
+            for (const specUrl of specsArray) {
+                await run(`
+                    INSERT INTO TestSpecs (test_run_implementation_id, test_run_version, test_full_name, spec_url)
+                    VALUES (?, ?, ?, ?)
+                `, [implemId, version, fullName, specUrl]);
+            }
         }
     }
 

--- a/munge_sql.js
+++ b/munge_sql.js
@@ -170,10 +170,13 @@ const main = async () => {
 
             const specsArray = test.meta?.specs || [];
             for (const specUrl of specsArray) {
+                // add `https://` if the specs don't have it
+                const cleanSpecUrl = specUrl.startsWith("http") ? specUrl : `https://${specUrl}`;
+
                 await run(`
                     INSERT INTO TestSpecs (test_run_implementation_id, test_run_version, test_full_name, spec_url)
                     VALUES (?, ?, ?, ?)
-                `, [implemId, version, fullName, specUrl]);
+                `, [implemId, version, fullName, cleanSpecUrl]);
             }
         }
     }

--- a/tests/path_gateway_dag_test.go
+++ b/tests/path_gateway_dag_test.go
@@ -42,7 +42,7 @@ func TestGatewayJsonCbor(t *testing.T) {
 		},
 		{
 			Name: "GET UnixFS file with JSON bytes is returned with application/json Content-Type - with headers",
-			Spec: "specs.ipfs.tech/http-gateways/path-gateway/#accept-request-header",
+			Spec: "https://specs.ipfs.tech/http-gateways/path-gateway/#accept-request-header",
 			Hint: `
 			## Quick regression check for JSON stored on UnixFS:
 			## it has nothing to do with DAG-JSON and JSON codecs,
@@ -479,7 +479,7 @@ func TestNativeDag(t *testing.T) {
 				Response: Expect().
 					Headers(
 						Header("Content-Type").Hint("expected Content-Type").Equals("application/vnd.ipld.dag-{{format}}", row.Format),
-						Header("Content-Length").Spec("specs.ipfs.tech/http-gateways/path-gateway/#content-disposition-response-header").Hint("includes Content-Length").Equals("{{length}}", len(dagTraversal.RawData())),
+						Header("Content-Length").Spec("https://specs.ipfs.tech/http-gateways/path-gateway/#content-disposition-response-header").Hint("includes Content-Length").Equals("{{length}}", len(dagTraversal.RawData())),
 						Header("Content-Disposition").Hint("includes Content-Disposition").Contains(`{{disposition}}; filename="{{cid}}.{{format}}"`, row.Disposition, dagTraversalCID, row.Format),
 						Header("X-Content-Type-Options").Hint("includes nosniff hint").Contains("nosniff"),
 					),
@@ -553,7 +553,7 @@ func TestNativeDag(t *testing.T) {
 			},
 			{
 				Name: Fmt("HEAD {{name}} with only-if-cached for missing block returns HTTP 412 Precondition Failed", row.Name),
-				Spec: "specs.ipfs.tech/http-gateways/path-gateway/#only-if-cached",
+				Spec: "https://specs.ipfs.tech/http-gateways/path-gateway/#only-if-cached",
 				Request: Request().
 					Path("/ipfs/{{cid}}", missingCID).
 					Header("Cache-Control", "only-if-cached").

--- a/tests/path_gateway_tar_test.go
+++ b/tests/path_gateway_tar_test.go
@@ -76,7 +76,7 @@ func TestTar(t *testing.T) {
 		},
 		{
 			Name: "GET TAR with explicit ?filename= succeeds with modified Content-Disposition header",
-			Spec: "specs.ipfs.tech/http-gateways/path-gateway/#content-disposition-response-header",
+			Spec: "https://specs.ipfs.tech/http-gateways/path-gateway/#content-disposition-response-header",
 			Request: Request().
 				Path("/ipfs/{{cid}}", dirCID).
 				Query("filename", "testтест.tar").

--- a/tests/path_gateway_unixfs_test.go
+++ b/tests/path_gateway_unixfs_test.go
@@ -202,7 +202,7 @@ func TestGatewayCache(t *testing.T) {
 		// ==========
 		{
 			Name: "GET for /ipfs/ file with matching Etag in If-None-Match returns 304 Not Modified",
-			Spec: "specs.ipfs.tech/http-gateways/path-gateway/#if-none-match-request-header",
+			Spec: "https://specs.ipfs.tech/http-gateways/path-gateway/#if-none-match-request-header",
 			Request: Request().
 				Path("/ipfs/{{cid}}/root2/root3/root4/index.html", fixture.MustGetCid()).
 				Headers(
@@ -213,7 +213,7 @@ func TestGatewayCache(t *testing.T) {
 		},
 		{
 			Name: "GET for /ipfs/ dir with index.html file with matching Etag in If-None-Match returns 304 Not Modified",
-			Spec: "specs.ipfs.tech/http-gateways/path-gateway/#if-none-match-request-header",
+			Spec: "https://specs.ipfs.tech/http-gateways/path-gateway/#if-none-match-request-header",
 			Request: Request().
 				Path("/ipfs/{{cid}}/root2/root3/root4/", fixture.MustGetCid()).
 				Headers(
@@ -224,7 +224,7 @@ func TestGatewayCache(t *testing.T) {
 		},
 		{
 			Name: "GET for /ipfs/ file with matching third Etag in If-None-Match returns 304 Not Modified",
-			Spec: "specs.ipfs.tech/http-gateways/path-gateway/#if-none-match-request-header",
+			Spec: "https://specs.ipfs.tech/http-gateways/path-gateway/#if-none-match-request-header",
 			Request: Request().
 				Path("/ipfs/{{cid}}/root2/root3/root4/index.html", fixture.MustGetCid()).
 				Headers(
@@ -235,7 +235,7 @@ func TestGatewayCache(t *testing.T) {
 		},
 		{
 			Name: "GET for /ipfs/ file with matching weak Etag in If-None-Match returns 304 Not Modified",
-			Spec: "specs.ipfs.tech/http-gateways/path-gateway/#if-none-match-request-header",
+			Spec: "https://specs.ipfs.tech/http-gateways/path-gateway/#if-none-match-request-header",
 			Request: Request().
 				Path("/ipfs/{{cid}}/root2/root3/root4/index.html", fixture.MustGetCid()).
 				Headers(
@@ -246,7 +246,7 @@ func TestGatewayCache(t *testing.T) {
 		},
 		{
 			Name: "GET for /ipfs/ file with wildcard Etag in If-None-Match returns 304 Not Modified",
-			Spec: "specs.ipfs.tech/http-gateways/path-gateway/#if-none-match-request-header",
+			Spec: "https://specs.ipfs.tech/http-gateways/path-gateway/#if-none-match-request-header",
 			Request: Request().
 				Path("/ipfs/{{cid}}/root2/root3/root4/index.html", fixture.MustGetCid()).
 				Headers(
@@ -257,7 +257,7 @@ func TestGatewayCache(t *testing.T) {
 		},
 		{
 			Name: "GET for /ipfs/ dir listing with matching weak Etag in If-None-Match returns 304 Not Modified",
-			Spec: "specs.ipfs.tech/http-gateways/path-gateway/#if-none-match-request-header",
+			Spec: "https://specs.ipfs.tech/http-gateways/path-gateway/#if-none-match-request-header",
 			Request: Request().
 				Path("/ipfs/{{cid}}/root2/root3/", fixture.MustGetCid()).
 				Headers(

--- a/tests/redirects_file_test.go
+++ b/tests/redirects_file_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 func TestRedirectsFileSupport(t *testing.T) {
-	tooling.LogSpecs(t, "specs.ipfs.tech/http-gateways/web-redirects-file/")
+	tooling.LogSpecs(t, "https://specs.ipfs.tech/http-gateways/web-redirects-file/")
 	fixture := car.MustOpenUnixfsCar("redirects_file/redirects.car")
 	redirectDir := fixture.MustGetNode("examples")
 	redirectDirCID := redirectDir.Base32Cid()
@@ -166,8 +166,8 @@ func TestRedirectsFileSupport(t *testing.T) {
 							Contains("could not parse _redirects:"),
 							Contains(`forced redirects (or "shadowing") are not supported`),
 						),
-					).Spec("specs.ipfs.tech/http-gateways/web-redirects-file/#no-forced-redirects"),
-				Spec: "specs.ipfs.tech/http-gateways/web-redirects-file/#error-handling",
+					).Spec("https://specs.ipfs.tech/http-gateways/web-redirects-file/#no-forced-redirects"),
+				Spec: "https://specs.ipfs.tech/http-gateways/web-redirects-file/#error-handling",
 			},
 			{
 				Name: "invalid file: request for $TOO_LARGE_REDIRECTS_DIR_HOSTNAME/not-found returns error about too large redirects file",
@@ -182,7 +182,7 @@ func TestRedirectsFileSupport(t *testing.T) {
 							Contains("redirects file size cannot exceed"),
 						),
 					),
-				Spec: "specs.ipfs.tech/http-gateways/web-redirects-file/#max-file-size",
+				Spec: "https://specs.ipfs.tech/http-gateways/web-redirects-file/#max-file-size",
 			},
 		}...)
 

--- a/tests/trustless_gateway_car_test.go
+++ b/tests/trustless_gateway_car_test.go
@@ -408,7 +408,7 @@ func TestTrustlessCarDagScopeAll(t *testing.T) {
 
 func TestTrustlessCarEntityBytes(t *testing.T) {
 	tooling.LogTestGroup(t, GroupBlockCar)
-	tooling.LogSpecs(t, "specs.ipfs.tech/http-gateways/trustless-gateway/#entity-bytes-request-query-parameter")
+	tooling.LogSpecs(t, "https://specs.ipfs.tech/http-gateways/trustless-gateway/#entity-bytes-request-query-parameter")
 
 	singleLayerHamtMultiBlockFilesFixture := car.MustOpenUnixfsCar("trustless_gateway_car/single-layer-hamt-with-multi-block-files.car")
 	subdirWithMixedBlockFiles := car.MustOpenUnixfsCar("trustless_gateway_car/subdir-with-mixed-block-files.car")

--- a/tests/trustless_gateway_raw_test.go
+++ b/tests/trustless_gateway_raw_test.go
@@ -14,7 +14,7 @@ import (
 
 func TestTrustlessRaw(t *testing.T) {
 	tooling.LogTestGroup(t, GroupBlockCar)
-	tooling.LogSpecs(t, "specs.ipfs.tech/http-gateways/trustless-gateway/#block-responses-application-vnd-ipld-raw")
+	tooling.LogSpecs(t, "https://specs.ipfs.tech/http-gateways/trustless-gateway/#block-responses-application-vnd-ipld-raw")
 
 	fixture := car.MustOpenUnixfsCar("gateway-raw-block.car")
 

--- a/www/content/_index.md
+++ b/www/content/_index.md
@@ -11,31 +11,26 @@ menu:
     <img src="{{< url "logo.png" >}}" class="w-32 h-32" />
     <div class="flex-grow">
       <p>
-      Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed tincidunt sagittis arcu, in tempus nisi molestie at. Suspendisse imperdiet viverra fringilla. Sed eleifend elementum sem. Phasellus orci lectus, laoreet in sapien vulputate, bibendum cursus neque. Quisque luctus dictum ligula, sit amet sagittis lacus consectetur eget. Phasellus non diam sem. Duis pellentesque tellus quis dolor sodales, vitae faucibus nulla ornare. Proin eget odio eu orci tristique volutpat. Nunc non vehicula neque. Maecenas volutpat mollis sem eget vestibulum.
-      </p>
+
+IPFS Gateway Conformance - a vendor-agnostic gateway conformance test suite for users and implementers of IPFS Gateways. We ensure compliance with [specs.ipfs.tech](https://specs.ipfs.tech/http-gateways/). Find us on [Github](https://github.com/ipfs/gateway-conformance).
+
+</p>
     </div>
   </div>
 </div>
 
-<div class="flex items-center justify-center my-3">
+<div class="flex items-center justify-center my-3 space-x-4">
     <a  href="{{< ref "/current" >}}"
-        class="no-underline bg-blue-200 hover:bg-blue-600 text-blue-800 hover:text-blue-200  text-xl px-8 py-4 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-200 focus:ring-offset-2">
-        Current Dashboard
+        class="no-underline bg-blue-200 hover:bg-blue-600 text-blue-800 hover:text-blue-200 text-xl px-8 py-4 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-200 focus:ring-offset-2">
+        Testing Dashboard
+    </a>
+    <a  href="{{< ref "/specs" >}}"
+        class="no-underline bg-blue-200 hover:bg-blue-600 text-blue-800 hover:text-blue-200 text-xl px-8 py-4 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-200 focus:ring-offset-2">
+        IPFS Specs Dashboard
     </a>
 </div>
 
-## List of Gateway Implementation Tested
-
-{{< gateways-links >}}
-
-## List of Specs Tested
-
-<a  href="{{< ref "/specs" >}}"
-    class="no-underline bg-blue-200 hover:bg-blue-600 text-blue-800 hover:text-blue-200  text-xl px-8 py-4 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-200 focus:ring-offset-2">
-    Specs
-</a>
-
-## Related Projects:
+## Related
 
 - [Conformance Test Suite](https://github.com/ipfs/gateway-conformance)
 - [IPFS Specs](https://specs.ipfs.tech)

--- a/www/content/_index.md
+++ b/www/content/_index.md
@@ -30,7 +30,10 @@ menu:
 
 ## List of Specs Tested
 
-{{< specs-links >}}
+<a  href="{{< ref "/specs" >}}"
+    class="no-underline bg-blue-200 hover:bg-blue-600 text-blue-800 hover:text-blue-200  text-xl px-8 py-4 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-200 focus:ring-offset-2">
+    Specs
+</a>
 
 ## Related Projects:
 

--- a/www/content/specs/_index.md
+++ b/www/content/specs/_index.md
@@ -1,4 +1,0 @@
----
----
-
-This is the entry-point for the conformance gateway dashboard when coming from the specs.

--- a/www/content/specs/_index.md
+++ b/www/content/specs/_index.md
@@ -1,0 +1,3 @@
+---
+title: Specification Dashboard
+---

--- a/www/themes/conformance/assets/style.css
+++ b/www/themes/conformance/assets/style.css
@@ -764,6 +764,10 @@ video {
   border-radius: 0.25rem;
 }
 
+.rounded-full {
+  border-radius: 9999px;
+}
+
 .rounded-lg {
   border-radius: 0.5rem;
 }
@@ -976,6 +980,11 @@ video {
   color: rgb(59 130 246 / var(--tw-text-opacity));
 }
 
+.text-blue-700 {
+  --tw-text-opacity: 1;
+  color: rgb(29 78 216 / var(--tw-text-opacity));
+}
+
 .text-blue-800 {
   --tw-text-opacity: 1;
   color: rgb(30 64 175 / var(--tw-text-opacity));
@@ -1041,6 +1050,20 @@ video {
   --tw-shadow: 0 20px 25px -5px rgb(0 0 0 / 0.1), 0 8px 10px -6px rgb(0 0 0 / 0.1);
   --tw-shadow-colored: 0 20px 25px -5px var(--tw-shadow-color), 0 8px 10px -6px var(--tw-shadow-color);
   box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.ring-1 {
+  --tw-ring-offset-shadow: var(--tw-ring-inset) 0 0 0 var(--tw-ring-offset-width) var(--tw-ring-offset-color);
+  --tw-ring-shadow: var(--tw-ring-inset) 0 0 0 calc(1px + var(--tw-ring-offset-width)) var(--tw-ring-color);
+  box-shadow: var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow, 0 0 #0000);
+}
+
+.ring-inset {
+  --tw-ring-inset: inset;
+}
+
+.ring-blue-700\/10 {
+  --tw-ring-color: rgb(29 78 216 / 0.1);
 }
 
 .transition {

--- a/www/themes/conformance/assets/style.css
+++ b/www/themes/conformance/assets/style.css
@@ -926,6 +926,11 @@ video {
   line-height: 2.25rem;
 }
 
+.text-5xl {
+  font-size: 3rem;
+  line-height: 1;
+}
+
 .text-sm {
   font-size: 0.875rem;
   line-height: 1.25rem;

--- a/www/themes/conformance/assets/style.css
+++ b/www/themes/conformance/assets/style.css
@@ -573,6 +573,14 @@ video {
   margin-bottom: auto;
 }
 
+.mb-3 {
+  margin-bottom: 0.75rem;
+}
+
+.mb-4 {
+  margin-bottom: 1rem;
+}
+
 .ml-4 {
   margin-left: 1rem;
 }
@@ -587,6 +595,14 @@ video {
 
 .mt-16 {
   margin-top: 4rem;
+}
+
+.mt-2 {
+  margin-top: 0.5rem;
+}
+
+.mt-8 {
+  margin-top: 2rem;
 }
 
 .block {
@@ -607,6 +623,10 @@ video {
 
 .table {
   display: table;
+}
+
+.grid {
+  display: grid;
 }
 
 .hidden {
@@ -669,6 +689,10 @@ video {
   table-layout: fixed;
 }
 
+.grid-cols-1 {
+  grid-template-columns: repeat(1, minmax(0, 1fr));
+}
+
 .flex-col {
   flex-direction: column;
 }
@@ -683,6 +707,10 @@ video {
 
 .justify-between {
   justify-content: space-between;
+}
+
+.gap-4 {
+  gap: 1rem;
 }
 
 .gap-x-2 {
@@ -802,6 +830,10 @@ video {
   padding: 0.375rem;
 }
 
+.p-4 {
+  padding: 1rem;
+}
+
 .p-6 {
   padding: 1.5rem;
 }
@@ -884,6 +916,16 @@ video {
   text-align: right;
 }
 
+.text-2xl {
+  font-size: 1.5rem;
+  line-height: 2rem;
+}
+
+.text-3xl {
+  font-size: 1.875rem;
+  line-height: 2.25rem;
+}
+
 .text-sm {
   font-size: 0.875rem;
   line-height: 1.25rem;
@@ -897,6 +939,10 @@ video {
 .text-xs {
   font-size: 0.75rem;
   line-height: 1rem;
+}
+
+.font-bold {
+  font-weight: 700;
 }
 
 .font-medium {
@@ -918,6 +964,11 @@ video {
 .text-amber-500 {
   --tw-text-opacity: 1;
   color: rgb(245 158 11 / var(--tw-text-opacity));
+}
+
+.text-blue-500 {
+  --tw-text-opacity: 1;
+  color: rgb(59 130 246 / var(--tw-text-opacity));
 }
 
 .text-blue-800 {
@@ -969,10 +1020,30 @@ video {
   text-decoration-line: none;
 }
 
+.shadow-md {
+  --tw-shadow: 0 4px 6px -1px rgb(0 0 0 / 0.1), 0 2px 4px -2px rgb(0 0 0 / 0.1);
+  --tw-shadow-colored: 0 4px 6px -1px var(--tw-shadow-color), 0 2px 4px -2px var(--tw-shadow-color);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
 .shadow-sm {
   --tw-shadow: 0 1px 2px 0 rgb(0 0 0 / 0.05);
   --tw-shadow-colored: 0 1px 2px 0 var(--tw-shadow-color);
   box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.shadow-xl {
+  --tw-shadow: 0 20px 25px -5px rgb(0 0 0 / 0.1), 0 8px 10px -6px rgb(0 0 0 / 0.1);
+  --tw-shadow-colored: 0 20px 25px -5px var(--tw-shadow-color), 0 8px 10px -6px var(--tw-shadow-color);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.transition {
+  transition-property: color, background-color, border-color, text-decoration-color, fill, stroke, opacity, box-shadow, transform, filter, -webkit-backdrop-filter;
+  transition-property: color, background-color, border-color, text-decoration-color, fill, stroke, opacity, box-shadow, transform, filter, backdrop-filter;
+  transition-property: color, background-color, border-color, text-decoration-color, fill, stroke, opacity, box-shadow, transform, filter, backdrop-filter, -webkit-backdrop-filter;
+  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+  transition-duration: 150ms;
 }
 
 article {
@@ -1169,6 +1240,11 @@ article th {
   background-color: rgb(37 99 235 / var(--tw-bg-opacity));
 }
 
+.hover\:bg-gray-100:hover {
+  --tw-bg-opacity: 1;
+  background-color: rgb(243 244 246 / var(--tw-bg-opacity));
+}
+
 .hover\:bg-slate-200:hover {
   --tw-bg-opacity: 1;
   background-color: rgb(226 232 240 / var(--tw-bg-opacity));
@@ -1177,6 +1253,11 @@ article th {
 .hover\:text-blue-200:hover {
   --tw-text-opacity: 1;
   color: rgb(191 219 254 / var(--tw-text-opacity));
+}
+
+.hover\:text-blue-700:hover {
+  --tw-text-opacity: 1;
+  color: rgb(29 78 216 / var(--tw-text-opacity));
 }
 
 .hover\:text-gray-500:hover {
@@ -1224,9 +1305,27 @@ article th {
   }
 }
 
+@media (min-width: 768px) {
+  .md\:grid-cols-1 {
+    grid-template-columns: repeat(1, minmax(0, 1fr));
+  }
+
+  .md\:grid-cols-2 {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
 @media (min-width: 1024px) {
   .lg\:mt-24 {
     margin-top: 6rem;
+  }
+
+  .lg\:grid-cols-1 {
+    grid-template-columns: repeat(1, minmax(0, 1fr));
+  }
+
+  .lg\:grid-cols-4 {
+    grid-template-columns: repeat(4, minmax(0, 1fr));
   }
 
   .lg\:px-8 {

--- a/www/themes/conformance/layouts/partials/breadcrumbs.html
+++ b/www/themes/conformance/layouts/partials/breadcrumbs.html
@@ -1,60 +1,49 @@
+{{ define "breadcrumbitem" }}
+  <li>
+    <div class="flex items-center">
+      {{ if (gt (len .Ancestors) 0) }}
+        <svg
+        class="h-5 w-5 flex-shrink-0 text-gray-300"
+        fill="currentColor"
+        viewBox="0 0 20 20"
+        aria-hidden="true"
+        >
+          <path d="M5.555 17.776l8-16 .894.448-8 16-.894-.448z" />
+        </svg>
+      <a
+        href="{{ .RelPermalink }}"
+        class="ml-4 text-sm font-medium text-gray-500 hover:text-gray-700"
+        aria-current="page"
+        >{{ .Title }}</a
+      >
+      {{ else }}
+        <a href="{{ .RelPermalink }}" class="text-gray-400 hover:text-gray-500">
+          <svg
+            class="h-5 w-5 flex-shrink-0"
+            viewBox="0 0 20 20"
+            fill="currentColor"
+            aria-hidden="true"
+          >
+            <path
+              fill-rule="evenodd"
+              d="M9.293 2.293a1 1 0 011.414 0l7 7A1 1 0 0117 11h-1v6a1 1 0 01-1 1h-2a1 1 0 01-1-1v-3a1 1 0 00-1-1H9a1 1 0 00-1 1v3a1 1 0 01-1 1H5a1 1 0 01-1-1v-6H3a1 1 0 01-.707-1.707l7-7z"
+              clip-rule="evenodd"
+            />
+          </svg>
+          <span class="sr-only">{{ .Title }}</span>
+        </a>
+      {{ end }}
+    </div>
+  </li>
+{{ end }}
+
 <div class="flex flex-col my-auto items-center">
   <nav class="flex" aria-label="Breadcrumb">
     <ol role="list" class="flex items-center space-x-4">
-      <li>
-        <div>
-          <a href="#" class="text-gray-400 hover:text-gray-500">
-            <svg
-              class="h-5 w-5 flex-shrink-0"
-              viewBox="0 0 20 20"
-              fill="currentColor"
-              aria-hidden="true"
-            >
-              <path
-                fill-rule="evenodd"
-                d="M9.293 2.293a1 1 0 011.414 0l7 7A1 1 0 0117 11h-1v6a1 1 0 01-1 1h-2a1 1 0 01-1-1v-3a1 1 0 00-1-1H9a1 1 0 00-1 1v3a1 1 0 01-1 1H5a1 1 0 01-1-1v-6H3a1 1 0 01-.707-1.707l7-7z"
-                clip-rule="evenodd"
-              />
-            </svg>
-            <span class="sr-only">Some</span>
-          </a>
-        </div>
-      </li>
-      <li>
-        <div class="flex items-center">
-          <svg
-            class="h-5 w-5 flex-shrink-0 text-gray-300"
-            fill="currentColor"
-            viewBox="0 0 20 20"
-            aria-hidden="true"
-          >
-            <path d="M5.555 17.776l8-16 .894.448-8 16-.894-.448z" />
-          </svg>
-          <a
-            href="#"
-            class="ml-4 text-sm font-medium text-gray-500 hover:text-gray-700"
-            >Breadcrumb</a
-          >
-        </div>
-      </li>
-      <li>
-        <div class="flex items-center">
-          <svg
-            class="h-5 w-5 flex-shrink-0 text-gray-300"
-            fill="currentColor"
-            viewBox="0 0 20 20"
-            aria-hidden="true"
-          >
-            <path d="M5.555 17.776l8-16 .894.448-8 16-.894-.448z" />
-          </svg>
-          <a
-            href="#"
-            class="ml-4 text-sm font-medium text-gray-500 hover:text-gray-700"
-            aria-current="page"
-            >Eventually</a
-          >
-        </div>
-      </li>
+      {{- range $i, $p := .Ancestors.Reverse }}
+        {{ template "breadcrumbitem" $p }}
+      {{ end }}
+      {{ template "breadcrumbitem" . }}
     </ol>
   </nav>
 </div>

--- a/www/themes/conformance/layouts/partials/result-table.html
+++ b/www/themes/conformance/layouts/partials/result-table.html
@@ -19,6 +19,18 @@
 {{ $requestedTestGroup := (default "null" .full_name) }}
 {{ $requestedVersion := (default "" .version) }}
 {{ $requestedImplem := (default "" .implementation_id) }}
+{{ $requestedSpecs := (default "" .spec_full_name) }}
+
+{{ $testGroups := (index site.Data.testgroups $requestedTestGroup) }}
+
+{{/*  When you have a request specs, list all the test groups it defines  */}}
+{{ if (isset . "spec_full_name") }}
+  {{ if (isset . "full_name") }}
+    {{ errorf "Cannot specify both 'full_name' and 'spec_full_name' in the same shortcode" }}
+  {{ end }}
+
+  {{ $testGroups = (index site.Data.specsgroups $requestedSpecs) }}
+{{ end }}
 
 <table class="min-w-full divide-y divide-gray-300 test-result table-fixed">
   <thead class="text-center">
@@ -95,7 +107,7 @@
           {{ end }}
         </tr>
       {{ end }}
-    {{ range $name, $content := (index site.Data.testgroups $requestedTestGroup) }}
+    {{ range $name, $content := $testGroups }}
       <tr class="text-center">
         <th scope="row" class="py-0.5 overflow-clip">
             <a class="text-right inline-block min-w-full px-2 py-1 text-sm font-semibold shadow-sm rounded bg-slate-50 hover:bg-slate-200"

--- a/www/themes/conformance/layouts/shortcodes/specs-links.html
+++ b/www/themes/conformance/layouts/shortcodes/specs-links.html
@@ -1,1 +1,12 @@
-TBD
+<ul>
+  {{ range $name, $details := site.Data.specs.null }}
+  <li>
+    <a
+      href="{{ absURL (path.Join "specs" $details.slug) }}"
+      class="px-2 py-1 text-md font-semibold"
+    >
+      {{ $name }}
+    </a>
+  </li>
+  {{ end }}
+</ul>

--- a/www/themes/conformance/layouts/specs/list.html
+++ b/www/themes/conformance/layouts/specs/list.html
@@ -54,7 +54,7 @@
   <!-- Main Dashboard with a different visual appeal -->
   <h3 class="text-3xl font-bold mb-4">
     Main Dashboard
-    {{ template "specpill" .Params.spec_full_name }}
+    {{ template "specpill" (default "https://specs.ipfs.tech/" .Params.spec_full_name) }}
   </h3>
   <div class="mt-2 p-6 shadow-xl rounded-lg">
     {{ partial "result-table.html" .Params }}

--- a/www/themes/conformance/layouts/specs/list.html
+++ b/www/themes/conformance/layouts/specs/list.html
@@ -1,3 +1,13 @@
+{{ define "specpill" }}
+  <a href="{{ . }}"
+     target="_blank"
+     rel="noopener noreferrer"
+     class="inline-flex items-center rounded-full bg-blue-50 px-2 py-1 text-xs font-medium text-blue-700 ring-1 ring-inset ring-blue-700/10 no-underline">
+    specs
+  </a>
+{{ end }}
+
+
 {{define "main"}}
 
 <article>
@@ -14,11 +24,14 @@
     <div class="grid grid-cols-1 md:grid-cols-1 lg:grid-cols-1 gap-4">
       <!-- Iterate through hashes and display each in a card format -->
       {{ range . }}
+        {{ $newSpec := (printf "%s/#%s" $params.spec_full_name .) }}
+  
         <div class="p-4 bg-white shadow-md rounded-lg">
           <h3 class="text-xl font-semibold mb-3">
             <a href="#{{ . }}" class="text-blue-500 hover:text-blue-700">#{{ . }}</a>
+            {{ template "specpill" $newSpec }}
           </h3>
-          {{ $newSpec := (printf "%s/#%s" $params.spec_full_name .) }}
+
           {{ partial "result-table.html" (merge $params (dict "spec_full_name" $newSpec))}}
         </div>
       {{ end }}
@@ -39,7 +52,10 @@
   {{ end }}
 
   <!-- Main Dashboard with a different visual appeal -->
-  <h3 class="text-3xl font-bold mb-4">Main Dashboard</h3>
+  <h3 class="text-3xl font-bold mb-4">
+    Main Dashboard
+    {{ template "specpill" .Params.spec_full_name }}
+  </h3>
   <div class="mt-2 p-6 shadow-xl rounded-lg">
     {{ partial "result-table.html" .Params }}
   </div>

--- a/www/themes/conformance/layouts/specs/list.html
+++ b/www/themes/conformance/layouts/specs/list.html
@@ -11,7 +11,10 @@
 {{define "main"}}
 
 <article>
-  <h2 class="text-5xl font-bold mb-4 text-center">{{.Title}}</h2>
+  <h2 class="text-5xl font-bold mb-4 text-center">
+    {{.Title}}
+    {{ template "specpill" (default "https://specs.ipfs.tech/" .Params.spec_full_name) }}
+  </h2>
 
 	{{.TableOfContents}}
 
@@ -54,7 +57,6 @@
   <!-- Main Dashboard with a different visual appeal -->
   <h3 class="text-3xl font-bold mb-4">
     Main Dashboard
-    {{ template "specpill" (default "https://specs.ipfs.tech/" .Params.spec_full_name) }}
   </h3>
   <div class="mt-2 p-6 shadow-xl rounded-lg">
     {{ partial "result-table.html" .Params }}

--- a/www/themes/conformance/layouts/specs/list.html
+++ b/www/themes/conformance/layouts/specs/list.html
@@ -1,0 +1,52 @@
+{{define "main"}}
+
+<article>
+	<h2>{{.Title}}</h2>
+
+	{{.TableOfContents}}
+
+	{{.Content}}
+
+  {{ with .Params.hashes }}
+    <h2>Hashes</h2>
+    <ul>
+      {{ range . }}
+      <li>
+        <a href="#{{ . }}">{{ . }}</a>
+      </li>
+      {{ end }}
+    </ul>
+  {{ end }}
+
+  {{ if (gt (len .Data.Pages) 0) }}
+    <h2>Children</h2>
+    <ul>
+      {{ range .Data.Pages }}
+          <li>
+              <a href="{{ .Permalink }}">{{ .Title }}</a>
+          </li>
+      {{ end }}
+    </ul>
+  {{ end }}
+</article>
+
+<!--Tag-->
+<ul>
+  {{range (.GetTerms "tags")}}
+<li><a href="{{.RelPermalink}}">{{.LinkTitle}}</a></li>
+  {{end}}
+</ul>
+
+<!--Prev/Next-->
+{{with .PrevInSection}}Prev <a href="{{.RelPermalink}}">{{.Title}}</a>{{end}}
+{{with .NextInSection}}Next <a href="{{.RelPermalink}}">{{.Title}}</a>{{end}}
+
+<!--Related-->
+{{$related := .Site.RegularPages.Related . | first 5}} {{with $related}}
+<h3>See Also</h3>
+<ul>
+  {{range .}}
+  <li><a href="{{.RelPermalink}}">{{.Title}}</a></li>
+  {{end}}
+</ul>
+{{end}} {{end}}

--- a/www/themes/conformance/layouts/specs/list.html
+++ b/www/themes/conformance/layouts/specs/list.html
@@ -7,27 +7,43 @@
 
 	{{.Content}}
 
+  {{ $params := .Params }}
+
+  <!-- If hashes exist -->
   {{ with .Params.hashes }}
-    <h2>Hashes</h2>
-    <ul>
+    <div class="grid grid-cols-1 md:grid-cols-1 lg:grid-cols-1 gap-4">
+      <!-- Iterate through hashes and display each in a card format -->
       {{ range . }}
-      <li>
-        <a href="#{{ . }}">{{ . }}</a>
-      </li>
+        <div class="p-4 bg-white shadow-md rounded-lg">
+          <h3 class="text-xl font-semibold mb-3">
+            <a href="#{{ . }}" class="text-blue-500 hover:text-blue-700">#{{ . }}</a>
+          </h3>
+          {{ $newSpec := (printf "%s/#%s" $params.spec_full_name .) }}
+          {{ partial "result-table.html" (merge $params (dict "spec_full_name" $newSpec))}}
+        </div>
       {{ end }}
-    </ul>
+    </div>
   {{ end }}
 
+  <!-- If child pages exist -->
   {{ if (gt (len .Data.Pages) 0) }}
-    <h2>Children</h2>
-    <ul>
+    <h2 class="text-2xl font-bold mt-8 mb-4">Sub-Specs</h2>
+    <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
+      <!-- Display each child page side by side -->
       {{ range .Data.Pages }}
-          <li>
-              <a href="{{ .Permalink }}">{{ .Title }}</a>
-          </li>
+        <a href="{{ .Permalink }}" class="p-4 bg-white shadow-md rounded-lg text-center hover:bg-gray-100 transition">
+          {{ .Title }}
+        </a>
       {{ end }}
-    </ul>
+    </div>
   {{ end }}
+
+  <!-- Main Dashboard with a different visual appeal -->
+  <h2 class="text-3xl font-bold mb-4">Main Dashboard</h2>
+  <div class="mt-2 p-6 shadow-xl rounded-lg">
+    {{ partial "result-table.html" .Params }}
+  </div>
+
 </article>
 
 <!--Tag-->

--- a/www/themes/conformance/layouts/specs/list.html
+++ b/www/themes/conformance/layouts/specs/list.html
@@ -1,7 +1,7 @@
 {{define "main"}}
 
 <article>
-	<h2>{{.Title}}</h2>
+  <h2 class="text-5xl font-bold mb-4 text-center">{{.Title}}</h2>
 
 	{{.TableOfContents}}
 
@@ -27,7 +27,7 @@
 
   <!-- If child pages exist -->
   {{ if (gt (len .Data.Pages) 0) }}
-    <h2 class="text-2xl font-bold mt-8 mb-4">Sub-Specs</h2>
+    <h3 class="text-2xl font-bold mt-8 mb-4">Sub-Specs</h3>
     <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
       <!-- Display each child page side by side -->
       {{ range .Data.Pages }}
@@ -39,7 +39,7 @@
   {{ end }}
 
   <!-- Main Dashboard with a different visual appeal -->
-  <h2 class="text-3xl font-bold mb-4">Main Dashboard</h2>
+  <h3 class="text-3xl font-bold mb-4">Main Dashboard</h3>
   <div class="mt-2 p-6 shadow-xl rounded-lg">
     {{ partial "result-table.html" .Params }}
   </div>


### PR DESCRIPTION
Contributes to https://github.com/ipfs/gateway-conformance/issues/123

Introduce specs dashboard side.

Example in https://singulargarden.github.io/gateway-conformance/specs/
We preserve the structure passed from specs.ipfs.tech to make linking and navigation easier.

For example:
https://singulargarden.github.io/gateway-conformance/specs/http-gateways/trustless-gateway/#entity-bytes-request-query-parameter


- [x] process the specs and render the `specs/a/b/c/` pages
- [x] render the dashboard for each specs, and the `#sub-spec-by-hash`
- [x] Add `https://` to the specs URL + add `Specs` field for multiple specs
- [x] Create spec -> tests & tests -> spec indexes
 
Note:

Tests are trees: `TestDagSomething/GET_Something/StatusCode`
And specs are also trees: `http-gateways/trustless-gateway/#entity-bytes-request-query-parameter`
What do you render for the spec `http-gateways/trustless-gateway`, especially if no tests are linking to that specific node in the tree?
The current PR renders all of its children, we'll have to refine this in further PRs.
