### PR TITLE
fix: escape names that might collide with other operations

### DIFF
--- a/munge_aggregates.js
+++ b/munge_aggregates.js
@@ -439,11 +439,6 @@ const slugifyTestName = (str) => {
     return x.join('/');
 }
 
-const extractTestName = (str) => {
-    let x = String(str).split('/');
-    return decodeURIComponent(x[x.length - 1]);
-}
-
 const outputJSON = (p, data) => {
     const json = JSON.stringify(data, null, 2);
     const fullPath = `${hugoOutput}/${p}`;

--- a/www/content/results/_index.md
+++ b/www/content/results/_index.md
@@ -1,0 +1,4 @@
+---
+title: Tests
+redirectsTo: /current
+---

--- a/www/content/tests/_index.md
+++ b/www/content/tests/_index.md
@@ -1,0 +1,4 @@
+---
+title: Tests
+redirectsTo: /current
+---

--- a/www/themes/conformance/layouts/partials/head.html
+++ b/www/themes/conformance/layouts/partials/head.html
@@ -1,2 +1,8 @@
 {{ $styles := resources.Get "style.css" }}
 <link rel="stylesheet" href="{{ $styles.RelPermalink }}">    
+
+{{ with .Params.RedirectsTo }}
+    <meta http-equiv="refresh" content="0; url={{ . | absURL }}"/>
+{{ end }}
+
+{{ .Params.RedirectsTo }}


### PR DESCRIPTION
Fixes the log rendering issue we've seen in bifrost

https://github.com/singulargarden/bifrost-gateway/actions/runs/6157325821/job/16707825616

Calling `t.Run("this is a test for /ipfs/something", ...)` will create outputs names like:
- `TestRoot/TestParent/this_is_a_test_for/ipfs/something/Body`

Which breaks the test generations and creates a _weird_ structure when rendering the tests.

- [x] Use HTML encoding to escape these names.
- [x] check the output and maybe un-encode


Examples:
- https://singulargarden.github.io/gateway-conformance/results/bifrost-gateway/main/test-gateway-cache
- https://singulargarden.github.io/gateway-conformance/tests/test-gateway-cache/get-for-ipfs-with-only-if-cached-succeeds-when-in-local-datastore/status-code/