### PR TITLE
Tests for `/ipns` paths and `Cache-Control` HTTP header

### DIFF
--- a/.github/workflows/test-kubo-e2e.yml
+++ b/.github/workflows/test-kubo-e2e.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        target: ['latest', 'master', 'ns-cleanup']
+        target: ['latest', 'master']
     defaults:
       run:
         shell: bash

--- a/.github/workflows/test-kubo-e2e.yml
+++ b/.github/workflows/test-kubo-e2e.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        target: ['latest', 'master']
+        target: ['latest', 'master', 'ns-cleanup']
     defaults:
       run:
         shell: bash

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+- Loosened the `Cache-Control` and `Last-Modified` checks for IPNS paths, as they are now allowed. [PR](https://github.com/ipfs/gateway-conformance/pull/173)
+
 ## [0.4.0] - 2023-10-02
 ### Added
 - Added tests for HTTP Range requests, as well as some basic helpers for `AnyOf` and `AllOf`. [PR](https://github.com/ipfs/gateway-conformance/pull/162)

--- a/tests/path_gateway_dag_test.go
+++ b/tests/path_gateway_dag_test.go
@@ -803,14 +803,19 @@ func TestGatewayJSONCborAndIPNS(t *testing.T) {
 				Request: Request().
 					Path("/ipns/{{id}}/", row.fixture.Key()).
 					Header("Accept", "text/html"),
-				Response: Expect().
-					Headers(
-						Header("Etag").Contains("DagIndex-"),
-						Header("Content-Type").Contains("text/html"),
-						Header("Content-Disposition").IsEmpty(),
-						// Header("Cache-Control").IsEmpty(),
-					).Body(
-					Contains("</html>"),
+				Response: AllOf(
+					Expect().
+						Headers(
+							Header("Etag").Contains("DagIndex-"),
+							Header("Content-Type").Contains("text/html"),
+							Header("Content-Disposition").IsEmpty(),
+						).Body(
+						Contains("</html>"),
+					),
+					AnyOf(
+						Expect().Headers(Header("Cache-Control").IsEmpty()),
+						Expect().Headers(Header("Cache-Control").Matches("public, max-age=*")),
+					),
 				),
 			},
 		}...)

--- a/tests/path_gateway_dag_test.go
+++ b/tests/path_gateway_dag_test.go
@@ -808,7 +808,7 @@ func TestGatewayJSONCborAndIPNS(t *testing.T) {
 						Header("Etag").Contains("DagIndex-"),
 						Header("Content-Type").Contains("text/html"),
 						Header("Content-Disposition").IsEmpty(),
-						Header("Cache-Control").IsEmpty(),
+						// Header("Cache-Control").IsEmpty(),
 					).Body(
 					Contains("</html>"),
 				),

--- a/tests/path_gateway_unixfs_test.go
+++ b/tests/path_gateway_unixfs_test.go
@@ -328,76 +328,92 @@ func TestGatewayCacheWithIPNS(t *testing.T) {
 			Name: "GET for /ipns/ unixfs dir listing succeeds",
 			Request: Request().
 				Path("/ipns/{{KEY}}/root2/root3/", ipnsKey),
-			Response: Expect().
-				Status(200).
-				Headers(
-					// Header("Cache-Control").
-					// 	IsEmpty(),
-					Header("X-Ipfs-Path").
-						Equals("/ipns/{{KEY}}/root2/root3/", ipnsKey),
-					Header("X-Ipfs-Roots").
-						Equals("{{CID1}},{{CID2}},{{CID3}}", fixture.MustGetCid(), fixture.MustGetCid("root2"), fixture.MustGetCid("root2", "root3")),
-					Header("Etag").
-						Matches("DirIndex-.*_CID-{{CID}}", fixture.MustGetCid("root2", "root3")),
+			Response: AllOf(
+				Expect().
+					Status(200).
+					Headers(
+						Header("X-Ipfs-Path").
+							Equals("/ipns/{{KEY}}/root2/root3/", ipnsKey),
+						Header("X-Ipfs-Roots").
+							Equals("{{CID1}},{{CID2}},{{CID3}}", fixture.MustGetCid(), fixture.MustGetCid("root2"), fixture.MustGetCid("root2", "root3")),
+						Header("Etag").
+							Matches("DirIndex-.*_CID-{{CID}}", fixture.MustGetCid("root2", "root3")),
+					),
+				AnyOf(
+					Expect().Headers(Header("Cache-Control").IsEmpty()),
+					Expect().Headers(Header("Cache-Control").Matches("public, max-age=*")),
 				),
+			),
 		},
 		{
 			Name: "GET for /ipns/ unixfs dir with index.html succeeds",
 			Request: Request().
 				Path("/ipns/{{KEY}}/root2/root3/root4/", ipnsKey),
-			Response: Expect().
-				Status(200).
-				Headers(
-					// Header("Cache-Control").
-					// 	IsEmpty(),
-					Header("X-Ipfs-Path").
-						Equals("/ipns/{{KEY}}/root2/root3/root4/", ipnsKey),
-					Header("X-Ipfs-Roots").
-						Equals("{{CID1}},{{CID2}},{{CID3}},{{CID4}}", fixture.MustGetCid(), fixture.MustGetCid("root2"), fixture.MustGetCid("root2", "root3"), fixture.MustGetCid("root2", "root3", "root4")),
-					Header("Etag").
-						Matches(`"{{CID}}"`, fixture.MustGetCid("root2", "root3", "root4")),
+			Response: AllOf(
+				Expect().
+					Status(200).
+					Headers(
+						Header("X-Ipfs-Path").
+							Equals("/ipns/{{KEY}}/root2/root3/root4/", ipnsKey),
+						Header("X-Ipfs-Roots").
+							Equals("{{CID1}},{{CID2}},{{CID3}},{{CID4}}", fixture.MustGetCid(), fixture.MustGetCid("root2"), fixture.MustGetCid("root2", "root3"), fixture.MustGetCid("root2", "root3", "root4")),
+						Header("Etag").
+							Matches(`"{{CID}}"`, fixture.MustGetCid("root2", "root3", "root4")),
+					),
+				AnyOf(
+					Expect().Headers(Header("Cache-Control").IsEmpty()),
+					Expect().Headers(Header("Cache-Control").Matches("public, max-age=*")),
 				),
+			),
 		},
 		{
 			Name: "GET for /ipns/ unixfs file succeeds",
 			Request: Request().
 				Path("/ipns/{{KEY}}/root2/root3/root4/index.html", ipnsKey),
-			Response: Expect().
-				Status(200).
-				Headers(
-					// Header("Cache-Control").
-					// 	IsEmpty(),
-					Header("X-Ipfs-Path").
-						Equals("/ipns/{{KEY}}/root2/root3/root4/index.html", ipnsKey),
-					Header("X-Ipfs-Roots").
-						Equals("{{CID1}},{{CID2}},{{CID3}},{{CID4}},{{CID5}}", fixture.MustGetCid(), fixture.MustGetCid("root2"), fixture.MustGetCid("root2", "root3"), fixture.MustGetCid("root2", "root3", "root4"), fixture.MustGetCid("root2", "root3", "root4", "index.html")),
-					Header("Etag").
-						Equals(`"{{CID}}"`, fixture.MustGetCid("root2", "root3", "root4", "index.html")),
+			Response: AllOf(
+				Expect().
+					Status(200).
+					Headers(
+						Header("X-Ipfs-Path").
+							Equals("/ipns/{{KEY}}/root2/root3/root4/index.html", ipnsKey),
+						Header("X-Ipfs-Roots").
+							Equals("{{CID1}},{{CID2}},{{CID3}},{{CID4}},{{CID5}}", fixture.MustGetCid(), fixture.MustGetCid("root2"), fixture.MustGetCid("root2", "root3"), fixture.MustGetCid("root2", "root3", "root4"), fixture.MustGetCid("root2", "root3", "root4", "index.html")),
+						Header("Etag").
+							Equals(`"{{CID}}"`, fixture.MustGetCid("root2", "root3", "root4", "index.html")),
+					),
+				AnyOf(
+					Expect().Headers(Header("Cache-Control").IsEmpty()),
+					Expect().Headers(Header("Cache-Control").Matches("public, max-age=*")),
 				),
+			),
 		},
 		{
 			Name: "GET for /ipns/ unixfs dir as DAG-JSON succeeds",
 			Request: Request().
 				Path("/ipns/{{KEY}}/root2/root3/root4/", ipnsKey).
 				Query("format", "dag-json"),
-			Response: Expect().
-				Status(200).
-				Headers(
-				// Header("Cache-Control").
-				// 	IsEmpty(),
+			Response: AllOf(
+				Expect().
+					Status(200),
+				AnyOf(
+					Expect().Headers(Header("Cache-Control").IsEmpty()),
+					Expect().Headers(Header("Cache-Control").Matches("public, max-age=*")),
 				),
+			),
 		},
 		{
 			Name: "GET for /ipns/ unixfs dir as JSON succeeds",
 			Request: Request().
 				Path("/ipns/{{KEY}}/root2/root3/root4/", ipnsKey).
 				Query("format", "json"),
-			Response: Expect().
-				Status(200).
-				Headers(
-				// Header("Cache-Control").
-				// 	IsEmpty(),
+			Response: AllOf(
+				Expect().
+					Status(200),
+				AnyOf(
+					Expect().Headers(Header("Cache-Control").IsEmpty()),
+					Expect().Headers(Header("Cache-Control").Matches("public, max-age=*")),
 				),
+			),
 		},
 		{
 			Name: "GET for /ipns/ file with matching Etag in If-None-Match returns 304 Not Modified",

--- a/tests/path_gateway_unixfs_test.go
+++ b/tests/path_gateway_unixfs_test.go
@@ -331,8 +331,8 @@ func TestGatewayCacheWithIPNS(t *testing.T) {
 			Response: Expect().
 				Status(200).
 				Headers(
-					Header("Cache-Control").
-						IsEmpty(),
+					// Header("Cache-Control").
+					// 	IsEmpty(),
 					Header("X-Ipfs-Path").
 						Equals("/ipns/{{KEY}}/root2/root3/", ipnsKey),
 					Header("X-Ipfs-Roots").
@@ -348,8 +348,8 @@ func TestGatewayCacheWithIPNS(t *testing.T) {
 			Response: Expect().
 				Status(200).
 				Headers(
-					Header("Cache-Control").
-						IsEmpty(),
+					// Header("Cache-Control").
+					// 	IsEmpty(),
 					Header("X-Ipfs-Path").
 						Equals("/ipns/{{KEY}}/root2/root3/root4/", ipnsKey),
 					Header("X-Ipfs-Roots").
@@ -365,8 +365,8 @@ func TestGatewayCacheWithIPNS(t *testing.T) {
 			Response: Expect().
 				Status(200).
 				Headers(
-					Header("Cache-Control").
-						IsEmpty(),
+					// Header("Cache-Control").
+					// 	IsEmpty(),
 					Header("X-Ipfs-Path").
 						Equals("/ipns/{{KEY}}/root2/root3/root4/index.html", ipnsKey),
 					Header("X-Ipfs-Roots").
@@ -383,8 +383,8 @@ func TestGatewayCacheWithIPNS(t *testing.T) {
 			Response: Expect().
 				Status(200).
 				Headers(
-					Header("Cache-Control").
-						IsEmpty(),
+				// Header("Cache-Control").
+				// 	IsEmpty(),
 				),
 		},
 		{
@@ -395,8 +395,8 @@ func TestGatewayCacheWithIPNS(t *testing.T) {
 			Response: Expect().
 				Status(200).
 				Headers(
-					Header("Cache-Control").
-						IsEmpty(),
+				// Header("Cache-Control").
+				// 	IsEmpty(),
 				),
 		},
 		{


### PR DESCRIPTION
This updates the conformance tests to bring them in line with the changes on the following PRs:

- https://github.com/ipfs/specs/pull/436
- https://github.com/ipfs/boxo/pull/459
- https://github.com/ipfs/kubo/pull/10115

Currently, we are not allowing `Cache-Control` headers in `/ipns` paths, but that's about to change.