### PR TITLE
docs(readme): docker extract-fixtures --s/output/directory/

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Prebuilt image at `ghcr.io/ipfs/gateway-conformance` can be used for both `test`
 
 ```console
 $ # extract fixtures to ./fixtures directory
-$ docker run -v "${PWD}:/workspace" -w "/workspace" ghcr.io/ipfs/gateway-conformance:vA.B.C extract-fixtures --output fixtures --merged false
+$ docker run -v "${PWD}:/workspace" -w "/workspace" ghcr.io/ipfs/gateway-conformance:vA.B.C extract-fixtures --directory fixtures --merged false
 
 $ # run subdomain-gateway tests against endpoint at http://localhost:8080
 $ docker run --network host -v "${PWD}:/workspace" -w "/workspace" ghcr.io/ipfs/gateway-conformance:vA.B.C test --gateway-url http://localhost:8080 --json report.json --specs +subdomain-gateway,-path-gateway -- -timeout 30m


### PR DESCRIPTION
```bash
> docker run -v "${PWD}:/workspace" -w "/workspace" ghcr.io/ipfs/gateway-conformance:v0.4.2 extract-fixtures --output fixtures --merged false
Status: Downloaded newer image for ghcr.io/ipfs/gateway-conformance:v0.4.2
Incorrect Usage: flag provided but not defined: -output

NAME:
   gateway-conformance extract-fixtures - Extract gateway testing fixtures that are used by the conformance test suite

USAGE:
   gateway-conformance extract-fixtures command [command options] [arguments...]

COMMANDS:
   help, h  Shows a list of commands or help for one command

OPTIONS:
   --directory value, --dir value  The directory to extract the fixtures to
   --merged                        Merge the fixtures into a single CAR file (default: false)
   --help, -h                      show help
2023/12/04 20:54:15 flag provided but not defined: -output
```