### PR TITLE
fix(tests): properly test negative indexing

### DIFF
--- a/tests/trustless_gateway_car_test.go
+++ b/tests/trustless_gateway_car_test.go
@@ -634,7 +634,7 @@ func TestTrustlessCarEntityBytes(t *testing.T) {
 						HasBlocks(
 							flattenStrings(t,
 								subdirWithMixedBlockFiles.MustGetCid("subdir", "multiblock.txt"),
-								subdirWithMixedBlockFiles.MustGetDescendantsCids("subdir", "multiblock.txt")[:5])...,
+								subdirWithMixedBlockFiles.MustGetDescendantsCids("subdir", "multiblock.txt")[:len(subdirWithMixedBlockFiles.MustGetDescendantsCids("subdir", "multiblock.txt"))-1])...,
 						).
 						Exactly().
 						InThatOrder(),


### PR DESCRIPTION
# Goals

Fix #189 

# Implementation

Insure `entity-bytes` negative index test properly verifies that the last block of the underlying file is not read.