### PR TITLE
fix(make): correctly infer ipns name from record filename

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ provision-cargateway: ./fixtures.car
 
 provision-kubo:
 	find ./fixtures -name '*.car' -exec ipfs dag import --stats --pin-roots=false {} \;
-	find ./fixtures -name '*.ipns-record' -exec sh -c 'ipfs routing put --allow-offline /ipns/$$(basename -s .ipns-record "{}") "{}"' \;
+	find ./fixtures -name '*.ipns-record' -exec sh -c 'ipfs routing put --allow-offline /ipns/$$(basename -s .ipns-record "{}" | cut -d'_' -f1) "{}"' \;
 
 # tools
 fixtures.car: gateway-conformance


### PR DESCRIPTION
Fixes the issue noted by @SgtPooki (#184) regarding `make provision-kubo`. It seems we forgot to update the Makefile to ignore everything after the `_` when we starting adding more information to the record filename.
