### PR TITLE
feat: remove range test for dag-cbor as text/html

### DIFF
--- a/tests/path_gateway_dag_test.go
+++ b/tests/path_gateway_dag_test.go
@@ -694,7 +694,6 @@ func TestNativeDag(t *testing.T) {
 		RunWithSpecs(t, rangeTests, specs.PathGatewayDAG)
 	}
 
-	var dagCborHTMLRendering []byte
 	RunWithSpecs(t, SugarTests{
 		SugarTest{
 			Name: "Convert application/vnd.ipld.dag-cbor to text/html",
@@ -704,34 +703,9 @@ func TestNativeDag(t *testing.T) {
 				Headers(
 					Header("Accept", "text/html"),
 				),
-			Response: Expect().Body(Checks("", func(t []byte) bool {
-				innerCheck := Contains("</html>").Check(string(t))
-				if innerCheck.Success {
-					dagCborHTMLRendering = t
-					return true
-				}
-				return false
-			})),
+			Response: Expect().Body(Contains("</html>")),
 		},
 	}, specs.PathGatewayDAG)
-
-	if dagCborHTMLRendering != nil {
-		rangeTests := helpers.OnlyRandomRangeTests(t,
-			SugarTest{
-				Name: "Convert application/vnd.ipld.dag-cbor to text/html with range request includes correct bytes",
-				Hint: "",
-				Request: Request().
-					Path("/ipfs/{{cid}}/", dagCborCID).
-					Headers(
-						Header("Accept", "text/html"),
-					),
-				Response: Expect(),
-			},
-			dagCborHTMLRendering,
-			"text/html")
-
-		RunWithSpecs(t, rangeTests, specs.PathGatewayDAG)
-	}
 }
 
 func TestGatewayJSONCborAndIPNS(t *testing.T) {


### PR DESCRIPTION
As per our conversation [here](https://github.com/ipfs/boxo/pull/587#pullrequestreview-1992168667), this removes the range test for `dag-cbor` objects that have been requested as `text/html`.