### PR TITLE
fix: Header().Has works properly for checking multiple values

### DIFF
--- a/tooling/check/check_has_test.go
+++ b/tooling/check/check_has_test.go
@@ -18,3 +18,16 @@ func TestCheckHas(t *testing.T) {
 
 	assert.True(t, checkOutput.Success, checkOutput.Reason)
 }
+
+func TestCheckHasFailure(t *testing.T) {
+	// Create a Check instance
+	check := Has("value3")
+
+	// Test data
+	testData := []string{"value1", "value2"}
+
+	// Call .Check on the instance
+	checkOutput := check.Check(testData)
+
+	assert.False(t, checkOutput.Success, checkOutput.Reason)
+}

--- a/tooling/check/check_has_test.go
+++ b/tooling/check/check_has_test.go
@@ -1,0 +1,20 @@
+package check
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCheckHas(t *testing.T) {
+	// Create a Check instance
+	check := Has("value1", "value2", "value3")
+
+	// Test data
+	testData := []string{"value1", "value2", "value3"}
+
+	// Call .Check on the instance
+	checkOutput := check.Check(testData)
+
+	assert.True(t, checkOutput.Success, checkOutput.Reason)
+}

--- a/tooling/test/header_test.go
+++ b/tooling/test/header_test.go
@@ -26,3 +26,21 @@ func TestHeader(t *testing.T) {
 	// Check if the headers satisfy the conditions
 	assert.True(t, checkOutput.Success, checkOutput.Reason)
 }
+
+func TestHeaderFailure(t *testing.T) {
+	resp := &http.Response{
+		Header: http.Header{
+			// missing X-Requested-With
+			"Access-Control-Allow-Headers": []string{"Content-Type, Range, User-Agent"},
+		},
+	}
+	// Extract headers from the response
+	headers := resp.Header["Access-Control-Allow-Headers"]
+
+	// Test the HeaderBuilder function
+	hb := Header("Access-Control-Allow-Headers").Has("Content-Type", "Range", "User-Agent", "X-Requested-With")
+
+	checkOutput := hb.Check_.Check(headers)
+
+	assert.False(t, checkOutput.Success, checkOutput.Reason)
+}

--- a/tooling/test/header_test.go
+++ b/tooling/test/header_test.go
@@ -1,0 +1,28 @@
+package test
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestHeader(t *testing.T) {
+	// Manually create a response object with headers
+	resp := &http.Response{
+		Header: http.Header{
+			"Access-Control-Allow-Headers": []string{"Content-Type, Range, User-Agent, X-Requested-With"},
+		},
+	}
+
+	// Extract headers from the response
+	headers := resp.Header["Access-Control-Allow-Headers"]
+
+	// Test the HeaderBuilder function
+	hb := Header("Access-Control-Allow-Headers").Has("Content-Type", "Range", "User-Agent", "X-Requested-With")
+
+	checkOutput := hb.Check_.Check(headers)
+
+	// Check if the headers satisfy the conditions
+	assert.True(t, checkOutput.Success, checkOutput.Reason)
+}

--- a/tooling/test/sugar.go
+++ b/tooling/test/sugar.go
@@ -436,7 +436,9 @@ func (h HeaderBuilder) Equals(value string, args ...any) HeaderBuilder {
 }
 
 func (h HeaderBuilder) Has(values ...string) HeaderBuilder {
-	h.Check_ = check.Has(values...)
+	for _, value := range values {
+		h.Check_ = check.IsUniqAnd(check.Contains(value))
+	}
 	return h
 }
 


### PR DESCRIPTION
Initial commit shows the problem mentioned in https://github.com/ipfs/gateway-conformance/issues/186

later commits fix the failing test

fixes https://github.com/ipfs/gateway-conformance/issues/186
contributes to #21