### PR TITLE
fix: Verify Cache-Control header for UnixFS directories

### DIFF
--- a/tests/path_gateway_unixfs_test.go
+++ b/tests/path_gateway_unixfs_test.go
@@ -90,7 +90,7 @@ func TestGatewayCache(t *testing.T) {
 				Status(200).
 				Headers(
 					Header("Cache-Control").
-						IsEmpty(),
+						Equals("public, max-age=604800, stale-while-revalidate=2678400"),
 					Header("X-Ipfs-Path").
 						Equals("/ipfs/{{CID}}/root2/root3/", fixture.MustGetCid()),
 					Header("X-Ipfs-Roots").


### PR DESCRIPTION
This PR relies on and is related to: https://github.com/ipfs/boxo/pull/639