### PR TITLE
fix: Cache-Control for generated UnixFS dir listings on /ipfs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.1] - 2024-07-29
+### Changed
+- Support meaningful `Cache-Control` on generated UnixFS directory listing responses on `/ipfs` namespace
+
 ## [0.6.0] - 2024-06-10
 ### Changed
 - Gateway URL

--- a/tests/path_gateway_unixfs_test.go
+++ b/tests/path_gateway_unixfs_test.go
@@ -90,7 +90,7 @@ func TestGatewayCache(t *testing.T) {
 				Status(200).
 				Headers(
 					Header("Cache-Control").
-						IsEmpty(),
+						Equals("public, max-age=604800, stale-while-revalidate=2678400"),
 					Header("X-Ipfs-Path").
 						Equals("/ipfs/{{CID}}/root2/root3/", fixture.MustGetCid()),
 					Header("X-Ipfs-Roots").

--- a/tests/path_gateway_unixfs_test.go
+++ b/tests/path_gateway_unixfs_test.go
@@ -84,20 +84,25 @@ func TestGatewayCache(t *testing.T) {
 	tests := SugarTests{
 		{
 			Name: "GET for /ipfs/ unixfs dir listing succeeds",
+			Hint: "UnixFS directory listings are generated HTML, which may change over time, and can't be cached forever. Still, should have a meaningful cache-control header.",
 			Request: Request().
 				Path("/ipfs/{{CID}}/root2/root3/", fixture.MustGetCid()),
-			Response: Expect().
-				Status(200).
-				Headers(
-					Header("Cache-Control").
-						Equals("public, max-age=604800, stale-while-revalidate=2678400"),
-					Header("X-Ipfs-Path").
-						Equals("/ipfs/{{CID}}/root2/root3/", fixture.MustGetCid()),
-					Header("X-Ipfs-Roots").
-						Equals("{{CID1}},{{CID2}},{{CID3}}", fixture.MustGetCid(), fixture.MustGetCid("root2"), fixture.MustGetCid("root2", "root3")),
-					Header("Etag").
-						Matches("DirIndex-.*_CID-{{cid}}", fixture.MustGetCid("root2", "root3")),
+			Response: AllOf(
+				Expect().
+					Status(200).
+					Headers(
+						Header("X-Ipfs-Path").
+							Equals("/ipfs/{{CID}}/root2/root3/", fixture.MustGetCid()),
+						Header("X-Ipfs-Roots").
+							Equals("{{CID1}},{{CID2}},{{CID3}}", fixture.MustGetCid(), fixture.MustGetCid("root2"), fixture.MustGetCid("root2", "root3")),
+						Header("Etag").
+							Matches("DirIndex-.*_CID-{{cid}}", fixture.MustGetCid("root2", "root3")),
+					),
+				AnyOf(
+					Expect().Headers(Header("Cache-Control").IsEmpty()),
+					Expect().Headers(Header("Cache-Control").Equals("public, max-age=604800, stale-while-revalidate=2678400")),
 				),
+			),
 		},
 		{
 			Name: "GET for /ipfs/ unixfs dir with index.html succeeds",


### PR DESCRIPTION
Applies https://github.com/ipfs/gateway-conformance/pull/218 in a backward-compatible way, allowing us to ship as a patch release while we finalize the specs.