### PR TITLE
fix(tar): test status and not body

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.2] - 2024-08-09
+### Changed
+- Relaxed negative test of TAR response [#221](https://github.com/ipfs/gateway-conformance/pull/221)
+
 ## [0.6.1] - 2024-07-29
 ### Changed
 - Support meaningful `Cache-Control` on generated UnixFS directory listing responses on `/ipfs` namespace

--- a/tests/path_gateway_tar_test.go
+++ b/tests/path_gateway_tar_test.go
@@ -89,13 +89,12 @@ func TestTar(t *testing.T) {
 		},
 		{
 			Name: "GET TAR with relative paths outside root fails",
+			Hint: "relative UnixFS paths outside the root are not allowed",
 			Request: Request().
 				Path("/ipfs/{{cid}}", outsideRootCID).
 				Query("format", "tar"),
 			Response: Expect().
-				Body(
-					Contains("relative UnixFS paths outside the root are not allowed"),
-				),
+				StatusBetween(400, 599),
 		},
 		{
 			Name: "GET TAR with relative paths inside root works",

--- a/tests/path_gateway_tar_test.go
+++ b/tests/path_gateway_tar_test.go
@@ -94,7 +94,7 @@ func TestTar(t *testing.T) {
 				Query("format", "tar"),
 			Response: Expect().
 				Body(
-					Contains("relative UnixFS paths outside the root are now allowed"),
+					Contains("relative UnixFS paths outside the root are not allowed"),
 				),
 		},
 		{


### PR DESCRIPTION
The error message in boxo was [fixed](https://github.com/ipfs/boxo/pull/653/files#diff-1f636927091be5710efa23d3ac59429fe81b9ddcc290ce4e6b276539a665f167L13-R13) to say "not allowed" instead of "now allowed". The message that the gateway conformance test looks for needs to match.