### PR TITLE
chore(ci): disable unused workflows

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -2,11 +2,11 @@ name: Deploy Pages
 
 on:
   workflow_dispatch:
-  push:
-    branches:
-      - main
-  schedule:
-    - cron: "1 * * * *" # every one hour
+  #push:
+  #  branches:
+  #    - main
+  #schedule:
+  #  - cron: "1 * * * *" # every one hour
 
 permissions:
   contents: read


### PR DESCRIPTION
the website was deprioritizedpost nucleation,
switching to on-demand build for now