### PR TITLE
fix: dag-index html cache-control matches dir-index html

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.1] - 2025-06-17
+### Changed
+- DAG-CBOR HTML preview pages previously had to be returned without Cache-Control headers. Now they can use Cache-Control headers similar to those used in generated UnixFS directory listings. [#241](https://github.com/ipfs/gateway-conformance/pull/241)
+
 ## [0.8.0] - 2025-05-28
 ### Changed
 - Comprehensive tests for HTTP Range Requests over deserialized UnixFS files have been added. The `--specs path-gateway` now requires support for at least single-range requests. Deserialized range-requests can be skipped with `--skip 'TestGatewayUnixFSFileRanges'` [#213](https://github.com/ipfs/gateway-conformance/pull/213)

--- a/tests/path_gateway_dag_test.go
+++ b/tests/path_gateway_dag_test.go
@@ -600,14 +600,21 @@ func TestNativeDag(t *testing.T) {
 				Request: Request().
 					Path("/ipfs/{{cid}}/", dagTraversalCID).
 					Header("Accept", "text/html"),
-				Response: Expect().
-					Headers(
-						Header("Etag").Contains("DagIndex-"),
-						Header("Content-Type").Contains("text/html"),
-						Header("Content-Disposition").IsEmpty(),
-						Header("Cache-Control").IsEmpty(),
-					).Body(
-					Contains("</html>"),
+				Response: AllOf(
+					Expect().
+						Status(200).
+						Headers(
+							Header("Etag").Contains("DagIndex-"),
+							Header("Content-Type").Contains("text/html"),
+							Header("Content-Disposition").IsEmpty(),
+						).
+						Body(
+							Contains("</html>"),
+						),
+					AnyOf(
+						Expect().Headers(Header("Cache-Control").IsEmpty()),
+						Expect().Headers(Header("Cache-Control").Equals("public, max-age=604800, stale-while-revalidate=2678400")),
+					),
 				),
 			},
 		}


### PR DESCRIPTION
Fixes https://github.com/ipfs/gateway-conformance/issues/240
