### PR TITLE
fix(check): no panic on non-JSON response body

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+
+### Changed
+
 ### Fixed
-- `check.CheckIsJSONEqual.Check` no longer panics when the gateway response body is not valid JSON (e.g. an HTML wrapper page or upstream error). It now returns a graceful failure that includes the parser error and offending body, so consumers can use Go's `-skip` to selectively skip leaf sub-tests like `.../GET_for/Body` without losing sibling coverage.
+
+## [0.13.2] - 2026-04-30
+### Fixed
+- `check.CheckIsJSONEqual.Check` no longer panics when the gateway response body is not valid JSON (e.g. an HTML wrapper page or upstream error). It now returns a graceful failure that includes the parser error and offending body, so consumers can use Go's `-skip` to selectively skip leaf sub-tests like `.../GET_for/Body` without losing sibling coverage. [#298](https://github.com/ipfs/gateway-conformance/pull/298)
 
 ## [0.13.1] - 2026-04-08
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Fixed
+- `check.CheckIsJSONEqual.Check` no longer panics when the gateway response body is not valid JSON (e.g. an HTML wrapper page or upstream error). It now returns a graceful failure that includes the parser error and offending body, so consumers can use Go's `-skip` to selectively skip leaf sub-tests like `.../GET_for/Body` without losing sibling coverage.
+
 ## [0.13.1] - 2026-04-08
 ### Fixed
 - Release workflow failed when changelog body contained special characters (`<`, `"`), preventing the v0.13.0 Docker image from being published. [#292](https://github.com/ipfs/gateway-conformance/pull/292)

--- a/tooling/check/check.go
+++ b/tooling/check/check.go
@@ -373,10 +373,12 @@ func IsJSONEqual(value []byte) Check[[]byte] {
 }
 
 func (c *CheckIsJSONEqual) Check(v []byte) CheckOutput {
-	var o map[string]any
-	err := json.Unmarshal(v, &o)
-	if err != nil {
-		panic(err) // TODO: move a t.Testing around to call `t.Fatal` on this case
+	var o any
+	if err := json.Unmarshal(v, &o); err != nil {
+		return CheckOutput{
+			Success: false,
+			Reason:  fmt.Sprintf("response body is not valid JSON: %s\nbody: %s", err, string(v)),
+		}
 	}
 
 	if reflect.DeepEqual(o, c.Value) {
@@ -387,7 +389,10 @@ func (c *CheckIsJSONEqual) Check(v []byte) CheckOutput {
 
 	b, err := json.Marshal(c.Value)
 	if err != nil {
-		panic(err) // TODO: move a t.Testing around to call `t.Fatal` on this case
+		return CheckOutput{
+			Success: false,
+			Reason:  fmt.Sprintf("could not marshal expected JSON value: %s", err),
+		}
 	}
 
 	return CheckOutput{

--- a/tooling/check/check_is_json_equal_test.go
+++ b/tooling/check/check_is_json_equal_test.go
@@ -1,0 +1,51 @@
+package check
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCheckIsJSONEqualMatch(t *testing.T) {
+	c := IsJSONEqual([]byte(`{"a":1,"b":[1,2,3]}`))
+
+	out := c.Check([]byte(`{"b":[1,2,3],"a":1}`))
+
+	assert.True(t, out.Success, out.Reason)
+}
+
+func TestCheckIsJSONEqualMismatch(t *testing.T) {
+	c := IsJSONEqual([]byte(`{"a":1}`))
+
+	out := c.Check([]byte(`{"a":2}`))
+
+	assert.False(t, out.Success)
+	assert.Contains(t, out.Reason, "expected")
+}
+
+// Regression: gateway responses that are not JSON (e.g. an HTML wrapper page or
+// upstream error) used to panic inside json.Unmarshal, taking the surrounding
+// sub-test down with it. Check should report a graceful failure instead so
+// callers can read the body from the failure reason and use Go's `-skip`
+// against leaf sub-tests like .../Body without losing sibling coverage.
+func TestCheckIsJSONEqualNonJSONBodyDoesNotPanic(t *testing.T) {
+	c := IsJSONEqual([]byte(`{"hello":"world"}`))
+
+	htmlBody := []byte(`<!doctype html><html><body>not json</body></html>`)
+
+	out := c.Check(htmlBody)
+
+	assert.False(t, out.Success)
+	assert.Contains(t, out.Reason, "not valid JSON")
+	assert.True(t, strings.Contains(out.Reason, "not json"), "reason should include the offending body for debugging, got: %s", out.Reason)
+}
+
+func TestCheckIsJSONEqualEmptyBodyDoesNotPanic(t *testing.T) {
+	c := IsJSONEqual([]byte(`{}`))
+
+	out := c.Check(nil)
+
+	assert.False(t, out.Success)
+	assert.Contains(t, out.Reason, "not valid JSON")
+}

--- a/tooling/test/validate_test.go
+++ b/tooling/test/validate_test.go
@@ -1,0 +1,53 @@
+package test
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/ipfs/gateway-conformance/tooling/check"
+	"github.com/stretchr/testify/assert"
+)
+
+// Regression: a gateway that returned a non-JSON body (e.g. an HTML wrapper
+// page) for a test using check.IsJSONEqual used to panic inside
+// json.Unmarshal, taking the parent sub-test down with it. validateResponse
+// must surface the failure as a normal Body check output instead, so that
+// consumers can use Go's `-skip` to skip the .../Body leaf without losing
+// sibling Status_code / Header_* coverage.
+//
+// See https://github.com/ipfs/service-worker-gateway/pull/1039 for the
+// downstream consumer that hit this.
+func TestValidateResponseIsJSONEqualOnHTMLBodyDoesNotPanic(t *testing.T) {
+	htmlBody := []byte(`<!doctype html><html><body>not json</body></html>`)
+
+	res := &http.Response{
+		StatusCode: 200,
+		Header:     http.Header{"Content-Type": []string{"text/html"}},
+		Body:       io.NopCloser(bytes.NewReader(htmlBody)),
+	}
+
+	expect := Expect().
+		Status(200).
+		Body(check.IsJSONEqual([]byte(`{"hello":"world"}`)))
+
+	var outputs []testCheckOutput
+	assert.NotPanics(t, func() {
+		outputs = validateResponse(t, expect, res)
+	})
+
+	var bodyOutput *testCheckOutput
+	for i := range outputs {
+		if outputs[i].testName == "Body" {
+			bodyOutput = &outputs[i]
+			break
+		}
+	}
+
+	assert.NotNil(t, bodyOutput, "expected a Body check output")
+	if bodyOutput != nil {
+		assert.False(t, bodyOutput.checkOutput.Success, "Body check must fail on non-JSON body")
+		assert.Contains(t, bodyOutput.checkOutput.Reason, "not valid JSON")
+	}
+}


### PR DESCRIPTION
CheckIsJSONEqual.Check called json.Unmarshal directly without recovering, so a gateway response that was not valid JSON (HTML wrapper page, upstream error, empty body) panicked and crashed the parent sub-test. The panic happened in validateResponse, before the .../Body and .../Header_Content-Type leaf sub-tests were dispatched, so consumers could not use Go's -skip to selectively skip a single body assertion while keeping sibling coverage.

## Details

- check.go: return CheckOutput{Success: false} with the parser error and the offending body in Reason instead of panicking; same shape for the marshal-error branch
- check.go: unmarshal into any rather than map[string]any so JSON arrays and scalars are also accepted (matches the IsJSONEqual constructor)
- check_is_json_equal_test.go: unit tests for match, mismatch, HTML body, empty body
- validate_test.go: integration test that drives validateResponse with a synthetic HTML response and asserts the failure surfaces under testName=="Body" so .../Body is -skip-addressable